### PR TITLE
feat(facturx): full EXTENDED 1.09 parity for models, converter and parser

### DIFF
--- a/src/lib/converters/facturx.ts
+++ b/src/lib/converters/facturx.ts
@@ -13,13 +13,17 @@ import type * as udt from '../models/facturx/unqualifiedTypes'
 import { parseXmlAsync } from 'libxmljs'
 
 /**
- * Converter for FacturX CrossIndustryInvoice model to XML
+ * Converter for FacturX CrossIndustryInvoice model to XML.
+ *
+ * Element emission follows the xs:sequence order of the Factur-X 1.09 (CII D22B)
+ * EXTENDED schema, which is a superset of all lower profiles. Only fields that
+ * are present on the model are emitted, so the same converter produces valid
+ * output for MINIMUM through EXTENDED.
  */
 export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<XMLDocument> {
-  // Create XML document with namespaces
   const xmlString = `<?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice 
-  xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" 
+<rsm:CrossIndustryInvoice
+  xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
   xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
   xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
   xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
@@ -29,80 +33,102 @@ export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<X
   const doc = await parseXmlAsync(xmlString)
   const rootElement = doc.root() as XMLElement
 
-  // Convert ExchangedDocumentContext
   convertExchangedDocumentContext(invoice.exchangedDocumentContext, rootElement)
-
-  // Convert ExchangedDocument
   convertExchangedDocument(invoice.exchangedDocument, rootElement)
-
-  // Convert SupplyChainTradeTransaction
   convertSupplyChainTradeTransaction(invoice.supplyChainTradeTransaction, rootElement)
 
   return doc
 }
 
-/**
- * Convert AmountType to XML
- */
+// ---------------------------------------------------------------------------
+// Primitive (Unqualified / Qualified data type) converters
+// ---------------------------------------------------------------------------
+
 function convertAmount({ value, currencyID }: udt.AmountType, parent: XMLElement): XMLElement {
   parent.text(value.toFixed(2))
-
   if (currencyID) {
     parent.attr({ currencyID })
   }
-
   return parent
 }
 
-/**
- * Convert IDType to XML
- */
 function convertID({ value, schemeID }: udt.IDType, parent: XMLElement): XMLElement {
   parent.text(value)
-
   if (schemeID) {
     parent.attr({ schemeID })
   }
-
   return parent
 }
 
-/**
- * Convert TextType to XML
- */
 function convertText({ value }: udt.TextType, parent: XMLElement): XMLElement {
   parent.text(value)
   return parent
 }
 
-/**
- * Convert DateTimeType to XML
- */
-function convertDateTime({ dateTimeString, format }: udt.DateTimeType, parent: XMLElement): XMLElement {
-  const dateTimeStringElement = parent.node('udt:DateTimeString', dateTimeString)
-  dateTimeStringElement.attr({ format })
-  return parent
-}
-/**
- * Convert DateType to XML
- */
-function convertDate({ dateString, format }: udt.DateType, parent: XMLElement): XMLElement {
-  const dateStringElement = parent.node('udt:DateString', dateString)
-  dateStringElement.attr({ format })
+function convertCode({ value, listID, listVersionID }: udt.CodeType, parent: XMLElement): XMLElement {
+  parent.text(value)
+  if (listID) {
+    parent.attr({ listID })
+  }
+  if (listVersionID) {
+    parent.attr({ listVersionID })
+  }
   return parent
 }
 
-/**
- * Convert IndicatorType to XML
- */
+function convertQuantity({ value, unitCode }: udt.QuantityType, parent: XMLElement): XMLElement {
+  parent.text(String(value))
+  if (unitCode) {
+    parent.attr({ unitCode })
+  }
+  return parent
+}
+
+function convertMeasure({ value, unitCode }: udt.MeasureType, parent: XMLElement): XMLElement {
+  parent.text(String(value))
+  if (unitCode) {
+    parent.attr({ unitCode })
+  }
+  return parent
+}
+
+function convertDateTime({ dateTimeString, format }: udt.DateTimeType, parent: XMLElement): XMLElement {
+  const el = parent.node('udt:DateTimeString', dateTimeString)
+  el.attr({ format })
+  return parent
+}
+
+function convertDate({ dateString, format }: udt.DateType, parent: XMLElement): XMLElement {
+  const el = parent.node('udt:DateString', dateString)
+  el.attr({ format })
+  return parent
+}
+
+/** FormattedDateTimeType uses the qdt:DateTimeString element (qualified namespace). */
+function convertFormattedDateTime(
+  { dateTimeString, format }: { dateTimeString: string, format: string },
+  parent: XMLElement,
+): XMLElement {
+  const el = parent.node('qdt:DateTimeString', dateTimeString)
+  el.attr({ format })
+  return parent
+}
+
 function convertIndicator({ indicator }: udt.IndicatorType, parent: XMLElement): XMLElement {
   parent.node('udt:Indicator', String(indicator))
   return parent
 }
 
-/**
- * Convert ExchangedDocumentContextType to XML
- */
+function convertBinaryObject({ value, mimeCode, filename }: udt.BinaryObjectType, parent: XMLElement): XMLElement {
+  parent.text(value)
+  parent.attr({ mimeCode, filename })
+  return parent
+}
+
+// ---------------------------------------------------------------------------
+// ExchangedDocumentContext
+// ---------------------------------------------------------------------------
+
 function convertExchangedDocumentContext(
   {
     testIndicator,
@@ -114,124 +140,97 @@ function convertExchangedDocumentContext(
   const context = parent.node('rsm:ExchangedDocumentContext')
 
   if (testIndicator) {
-    const testIndicatorEl = context.node('ram:TestIndicator')
-    convertIndicator(testIndicator, testIndicatorEl)
+    convertIndicator(testIndicator, context.node('ram:TestIndicator'))
   }
 
   if (businessProcessSpecifiedDocumentContextParameter) {
-    const businessProcessEl = context.node('ram:BusinessProcessSpecifiedDocumentContextParameter')
-    convertDocumentContextParameter(businessProcessSpecifiedDocumentContextParameter, businessProcessEl)
+    convertDocumentContextParameter(
+      businessProcessSpecifiedDocumentContextParameter,
+      context.node('ram:BusinessProcessSpecifiedDocumentContextParameter'),
+    )
   }
 
-  const guidelineEl = context.node('ram:GuidelineSpecifiedDocumentContextParameter')
-  convertDocumentContextParameter(guidelineSpecifiedDocumentContextParameter, guidelineEl)
+  convertDocumentContextParameter(
+    guidelineSpecifiedDocumentContextParameter,
+    context.node('ram:GuidelineSpecifiedDocumentContextParameter'),
+  )
 }
 
-/**
- * Convert DocumentContextParameterType to XML
- */
-function convertDocumentContextParameter(
-  { id }: ram.DocumentContextParameterType,
-  parent: XMLElement,
-): void {
-  const idEl = parent.node('ram:ID')
-  convertID(id, idEl)
+function convertDocumentContextParameter({ id }: ram.DocumentContextParameterType, parent: XMLElement): void {
+  convertID(id, parent.node('ram:ID'))
 }
 
-/**
- * Convert ExchangedDocumentType to XML
- */
+// ---------------------------------------------------------------------------
+// ExchangedDocument
+// ---------------------------------------------------------------------------
+
 function convertExchangedDocument(
   { id, name, typeCode, issueDateTime, copyIndicator, languageID, includedNote, effectiveSpecifiedPeriod }: ExchangedDocumentType,
   parent: XMLElement,
 ): void {
   const doc = parent.node('rsm:ExchangedDocument')
 
-  const idEl = doc.node('ram:ID')
-  convertID(id, idEl)
+  convertID(id, doc.node('ram:ID'))
 
   if (name) {
-    const nameEl = doc.node('ram:Name')
-    convertText(name, nameEl)
+    convertText(name, doc.node('ram:Name'))
   }
 
-  const typeCodeEl = doc.node('ram:TypeCode')
-  typeCodeEl.text(typeCode.value)
+  doc.node('ram:TypeCode', typeCode.value)
 
-  const issueDateTimeEl = doc.node('ram:IssueDateTime')
-  convertDateTime(issueDateTime, issueDateTimeEl)
+  convertDateTime(issueDateTime, doc.node('ram:IssueDateTime'))
 
   if (copyIndicator) {
-    const copyIndicatorEl = doc.node('ram:CopyIndicator')
-    convertIndicator(copyIndicator, copyIndicatorEl)
+    convertIndicator(copyIndicator, doc.node('ram:CopyIndicator'))
   }
 
   if (languageID && languageID.length > 0) {
-    languageID.forEach((lang) => {
-      const langEl = doc.node('ram:LanguageID')
-      convertID(lang, langEl)
-    })
+    languageID.forEach(lang => convertID(lang, doc.node('ram:LanguageID')))
   }
 
   if (includedNote && includedNote.length > 0) {
-    includedNote.forEach(note => convertNote(note, doc))
+    includedNote.forEach(note => convertNote(note, doc.node('ram:IncludedNote')))
   }
 
   if (effectiveSpecifiedPeriod) {
-    const periodEl = doc.node('ram:EffectiveSpecifiedPeriod')
-    convertSpecifiedPeriod(effectiveSpecifiedPeriod, periodEl)
+    convertSpecifiedPeriod(effectiveSpecifiedPeriod, doc.node('ram:EffectiveSpecifiedPeriod'))
   }
 }
 
-/**
- * Convert NoteType to XML
- */
-function convertNote(
-  { content, subjectCode }: ram.NoteType,
-  parent: XMLElement,
-): void {
-  const noteEl = parent.node('ram:IncludedNote')
-
-  const contentEl = noteEl.node('ram:Content')
-  convertText(content, contentEl)
-
+function convertNote({ contentCode, content, subjectCode }: ram.NoteType, parent: XMLElement): void {
+  if (contentCode) {
+    convertCode(contentCode, parent.node('ram:ContentCode'))
+  }
+  if (content) {
+    convertText(content, parent.node('ram:Content'))
+  }
   if (subjectCode) {
-    const subjectCodeEl = noteEl.node('ram:SubjectCode')
-    convertText(subjectCode, subjectCodeEl)
+    convertCode(subjectCode, parent.node('ram:SubjectCode'))
   }
 }
 
-/**
- * Convert SpecifiedPeriodType to XML
- */
 function convertSpecifiedPeriod(
-  { startDateTime, endDateTime, completeDateTime, description }: ram.SpecifiedPeriodType,
+  { description, startDateTime, endDateTime, completeDateTime }: ram.SpecifiedPeriodType,
   parent: XMLElement,
 ): void {
-  if (startDateTime) {
-    const startDateTimeEl = parent.node('ram:StartDateTime')
-    convertDateTime(startDateTime, startDateTimeEl)
-  }
-
-  if (endDateTime) {
-    const endDateTimeEl = parent.node('ram:EndDateTime')
-    convertDateTime(endDateTime, endDateTimeEl)
-  }
-
-  if (completeDateTime) {
-    const completeDateTimeEl = parent.node('ram:CompleteDateTime')
-    convertDateTime(completeDateTime, completeDateTimeEl)
-  }
-
   if (description) {
-    const descriptionEl = parent.node('ram:Description')
-    convertText(description, descriptionEl)
+    convertText(description, parent.node('ram:Description'))
+  }
+  if (startDateTime) {
+    convertDateTime(startDateTime, parent.node('ram:StartDateTime'))
+  }
+  if (endDateTime) {
+    convertDateTime(endDateTime, parent.node('ram:EndDateTime'))
+  }
+  if (completeDateTime) {
+    convertDateTime(completeDateTime, parent.node('ram:CompleteDateTime'))
   }
 }
 
-/**
- * Convert SupplyChainTradeTransactionType to XML
- */
+// ---------------------------------------------------------------------------
+// SupplyChainTradeTransaction
+// ---------------------------------------------------------------------------
+
 function convertSupplyChainTradeTransaction(
   {
     includedSupplyChainTradeLineItem,
@@ -243,298 +242,601 @@ function convertSupplyChainTradeTransaction(
 ): void {
   const transaction = parent.node('rsm:SupplyChainTradeTransaction')
 
-  // Include line items before the header elements
   if (includedSupplyChainTradeLineItem && includedSupplyChainTradeLineItem.length > 0) {
     includedSupplyChainTradeLineItem.forEach((lineItem) => {
-      const lineItemEl = transaction.node('ram:IncludedSupplyChainTradeLineItem')
-      convertSupplyChainTradeLineItem(lineItem, lineItemEl)
+      convertSupplyChainTradeLineItem(lineItem, transaction.node('ram:IncludedSupplyChainTradeLineItem'))
     })
   }
 
-  // Convert header trade agreement - required element
-  const agreementEl = transaction.node('ram:ApplicableHeaderTradeAgreement')
-  convertHeaderTradeAgreement(applicableHeaderTradeAgreement, agreementEl)
-
-  // Convert header trade delivery - required element
-  const deliveryEl = transaction.node('ram:ApplicableHeaderTradeDelivery')
-  convertHeaderTradeDelivery(applicableHeaderTradeDelivery, deliveryEl)
-
-  // Convert header trade settlement - required element
-  const settlementEl = transaction.node('ram:ApplicableHeaderTradeSettlement')
-  convertHeaderTradeSettlement(applicableHeaderTradeSettlement, settlementEl)
+  convertHeaderTradeAgreement(applicableHeaderTradeAgreement, transaction.node('ram:ApplicableHeaderTradeAgreement'))
+  convertHeaderTradeDelivery(applicableHeaderTradeDelivery, transaction.node('ram:ApplicableHeaderTradeDelivery'))
+  convertHeaderTradeSettlement(applicableHeaderTradeSettlement, transaction.node('ram:ApplicableHeaderTradeSettlement'))
 }
 
-/**
- * Convert SupplyChainTradeLineItemType to XML
- */
-function convertSupplyChainTradeLineItem(
-  lineItem: ram.SupplyChainTradeLineItemType,
-  parent: XMLElement,
-): void {
-  if (lineItem.associatedDocumentLineDocument) {
-    const docLineEl = parent.node('ram:AssociatedDocumentLineDocument')
+// ---------------------------------------------------------------------------
+// Line items
+// ---------------------------------------------------------------------------
 
-    if (lineItem.associatedDocumentLineDocument.lineID) {
-      const lineIDEl = docLineEl.node('ram:LineID')
-      convertID(lineItem.associatedDocumentLineDocument.lineID, lineIDEl)
-    }
-  }
-
-  if (lineItem.specifiedTradeProduct) {
-    const productEl = parent.node('ram:SpecifiedTradeProduct')
-
-    if (lineItem.specifiedTradeProduct.globalID) {
-      const globalIDEl = productEl.node('ram:GlobalID')
-      convertID(lineItem.specifiedTradeProduct.globalID, globalIDEl)
-    }
-
-    if (lineItem.specifiedTradeProduct.name) {
-      const nameEl = productEl.node('ram:Name')
-      convertText(lineItem.specifiedTradeProduct.name, nameEl)
-    }
-
-    if (lineItem.specifiedTradeProduct.description) {
-      const descEl = productEl.node('ram:Description')
-      convertText(lineItem.specifiedTradeProduct.description, descEl)
-    }
-  }
+function convertSupplyChainTradeLineItem(lineItem: ram.SupplyChainTradeLineItemType, parent: XMLElement): void {
+  convertDocumentLineDocument(lineItem.associatedDocumentLineDocument, parent.node('ram:AssociatedDocumentLineDocument'))
+  convertTradeProduct(lineItem.specifiedTradeProduct, parent.node('ram:SpecifiedTradeProduct'))
 
   if (lineItem.specifiedLineTradeAgreement) {
-    const agreementEl = parent.node('ram:SpecifiedLineTradeAgreement')
-    convertLineTradeAgreement(lineItem.specifiedLineTradeAgreement, agreementEl)
+    convertLineTradeAgreement(lineItem.specifiedLineTradeAgreement, parent.node('ram:SpecifiedLineTradeAgreement'))
   }
-
   if (lineItem.specifiedLineTradeDelivery) {
-    const deliveryEl = parent.node('ram:SpecifiedLineTradeDelivery')
-    convertLineTradeDelivery(lineItem.specifiedLineTradeDelivery, deliveryEl)
+    convertLineTradeDelivery(lineItem.specifiedLineTradeDelivery, parent.node('ram:SpecifiedLineTradeDelivery'))
   }
-
   if (lineItem.specifiedLineTradeSettlement) {
-    const settlementEl = parent.node('ram:SpecifiedLineTradeSettlement')
-    convertLineTradeSettlement(lineItem.specifiedLineTradeSettlement, settlementEl)
+    convertLineTradeSettlement(lineItem.specifiedLineTradeSettlement, parent.node('ram:SpecifiedLineTradeSettlement'))
   }
 }
 
-/**
- * Convert HeaderTradeAgreementType to XML
- */
+function convertDocumentLineDocument(
+  { lineID, parentLineID, lineStatusCode, lineStatusReasonCode, includedNote }: ram.DocumentLineDocumentType,
+  parent: XMLElement,
+): void {
+  convertID(lineID, parent.node('ram:LineID'))
+  if (parentLineID) {
+    convertID(parentLineID, parent.node('ram:ParentLineID'))
+  }
+  if (lineStatusCode) {
+    parent.node('ram:LineStatusCode', lineStatusCode.value)
+  }
+  if (lineStatusReasonCode) {
+    convertCode(lineStatusReasonCode, parent.node('ram:LineStatusReasonCode'))
+  }
+  if (includedNote && includedNote.length > 0) {
+    includedNote.forEach(note => convertNote(note, parent.node('ram:IncludedNote')))
+  }
+}
+
+function convertTradeProduct(
+  {
+    id,
+    globalID,
+    sellerAssignedID,
+    buyerAssignedID,
+    industryAssignedID,
+    modelID,
+    name,
+    description,
+    batchID,
+    brandName,
+    modelName,
+    applicableProductCharacteristic,
+    designatedProductClassification,
+    individualTradeProductInstance,
+    originTradeCountry,
+    manufacturerTradeParty,
+    includedReferencedProduct,
+  }: ram.TradeProductType,
+  parent: XMLElement,
+): void {
+  if (id) {
+    convertID(id, parent.node('ram:ID'))
+  }
+  if (globalID) {
+    convertID(globalID, parent.node('ram:GlobalID'))
+  }
+  if (sellerAssignedID) {
+    convertID(sellerAssignedID, parent.node('ram:SellerAssignedID'))
+  }
+  if (buyerAssignedID) {
+    convertID(buyerAssignedID, parent.node('ram:BuyerAssignedID'))
+  }
+  if (industryAssignedID) {
+    convertID(industryAssignedID, parent.node('ram:IndustryAssignedID'))
+  }
+  if (modelID) {
+    convertID(modelID, parent.node('ram:ModelID'))
+  }
+  if (name) {
+    convertText(name, parent.node('ram:Name'))
+  }
+  if (description) {
+    convertText(description, parent.node('ram:Description'))
+  }
+  if (batchID && batchID.length > 0) {
+    batchID.forEach(b => convertID(b, parent.node('ram:BatchID')))
+  }
+  if (brandName) {
+    convertText(brandName, parent.node('ram:BrandName'))
+  }
+  if (modelName) {
+    convertText(modelName, parent.node('ram:ModelName'))
+  }
+  if (applicableProductCharacteristic && applicableProductCharacteristic.length > 0) {
+    applicableProductCharacteristic.forEach(c => convertProductCharacteristic(c, parent.node('ram:ApplicableProductCharacteristic')))
+  }
+  if (designatedProductClassification && designatedProductClassification.length > 0) {
+    designatedProductClassification.forEach(c => convertProductClassification(c, parent.node('ram:DesignatedProductClassification')))
+  }
+  if (individualTradeProductInstance && individualTradeProductInstance.length > 0) {
+    individualTradeProductInstance.forEach(i => convertTradeProductInstance(i, parent.node('ram:IndividualTradeProductInstance')))
+  }
+  if (originTradeCountry?.id) {
+    parent.node('ram:OriginTradeCountry').node('ram:ID', originTradeCountry.id.value)
+  }
+  if (manufacturerTradeParty) {
+    convertTradeParty(manufacturerTradeParty, parent.node('ram:ManufacturerTradeParty'))
+  }
+  if (includedReferencedProduct && includedReferencedProduct.length > 0) {
+    includedReferencedProduct.forEach(p => convertReferencedProduct(p, parent.node('ram:IncludedReferencedProduct')))
+  }
+}
+
+function convertProductCharacteristic(
+  { typeCode, description, valueMeasure, value }: ram.ProductCharacteristicType,
+  parent: XMLElement,
+): void {
+  if (typeCode) {
+    convertCode(typeCode, parent.node('ram:TypeCode'))
+  }
+  if (description) {
+    convertText(description, parent.node('ram:Description'))
+  }
+  if (valueMeasure) {
+    convertMeasure(valueMeasure, parent.node('ram:ValueMeasure'))
+  }
+  if (value) {
+    convertText(value, parent.node('ram:Value'))
+  }
+}
+
+function convertProductClassification(
+  { classCode, className }: ram.ProductClassificationType,
+  parent: XMLElement,
+): void {
+  if (classCode) {
+    convertCode(classCode, parent.node('ram:ClassCode'))
+  }
+  if (className) {
+    convertText(className, parent.node('ram:ClassName'))
+  }
+}
+
+function convertTradeProductInstance(
+  { batchID, supplierAssignedSerialID }: ram.TradeProductInstanceType,
+  parent: XMLElement,
+): void {
+  if (batchID) {
+    convertID(batchID, parent.node('ram:BatchID'))
+  }
+  if (supplierAssignedSerialID) {
+    convertID(supplierAssignedSerialID, parent.node('ram:SupplierAssignedSerialID'))
+  }
+}
+
+function convertReferencedProduct(
+  { id, globalID, sellerAssignedID, buyerAssignedID, industryAssignedID, name, description, unitQuantity }: ram.ReferencedProductType,
+  parent: XMLElement,
+): void {
+  if (id) {
+    convertID(id, parent.node('ram:ID'))
+  }
+  if (globalID && globalID.length > 0) {
+    globalID.forEach(g => convertID(g, parent.node('ram:GlobalID')))
+  }
+  if (sellerAssignedID) {
+    convertID(sellerAssignedID, parent.node('ram:SellerAssignedID'))
+  }
+  if (buyerAssignedID) {
+    convertID(buyerAssignedID, parent.node('ram:BuyerAssignedID'))
+  }
+  if (industryAssignedID) {
+    convertID(industryAssignedID, parent.node('ram:IndustryAssignedID'))
+  }
+  convertText(name, parent.node('ram:Name'))
+  if (description) {
+    convertText(description, parent.node('ram:Description'))
+  }
+  if (unitQuantity) {
+    convertQuantity(unitQuantity, parent.node('ram:UnitQuantity'))
+  }
+}
+
+function convertLineTradeAgreement(
+  {
+    applicableTradeDeliveryTerms,
+    sellerOrderReferencedDocument,
+    buyerOrderReferencedDocument,
+    quotationReferencedDocument,
+    contractReferencedDocument,
+    additionalReferencedDocument,
+    grossPriceProductTradePrice,
+    netPriceProductTradePrice,
+    itemSellerTradeParty,
+    ultimateCustomerOrderReferencedDocument,
+  }: ram.LineTradeAgreementType,
+  parent: XMLElement,
+): void {
+  if (applicableTradeDeliveryTerms) {
+    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.node('ram:ApplicableTradeDeliveryTerms'))
+  }
+  if (sellerOrderReferencedDocument) {
+    convertReferencedDocument(sellerOrderReferencedDocument, parent.node('ram:SellerOrderReferencedDocument'))
+  }
+  if (buyerOrderReferencedDocument) {
+    convertReferencedDocument(buyerOrderReferencedDocument, parent.node('ram:BuyerOrderReferencedDocument'))
+  }
+  if (quotationReferencedDocument) {
+    convertReferencedDocument(quotationReferencedDocument, parent.node('ram:QuotationReferencedDocument'))
+  }
+  if (contractReferencedDocument) {
+    convertReferencedDocument(contractReferencedDocument, parent.node('ram:ContractReferencedDocument'))
+  }
+  if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+  }
+  if (grossPriceProductTradePrice) {
+    convertTradePrice(grossPriceProductTradePrice, parent.node('ram:GrossPriceProductTradePrice'))
+  }
+  if (netPriceProductTradePrice) {
+    convertTradePrice(netPriceProductTradePrice, parent.node('ram:NetPriceProductTradePrice'))
+  }
+  if (itemSellerTradeParty) {
+    convertTradeParty(itemSellerTradeParty, parent.node('ram:ItemSellerTradeParty'))
+  }
+  if (ultimateCustomerOrderReferencedDocument && ultimateCustomerOrderReferencedDocument.length > 0) {
+    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:UltimateCustomerOrderReferencedDocument')))
+  }
+}
+
+function convertTradePrice(
+  { chargeAmount, basisQuantity, appliedTradeAllowanceCharge, includedTradeTax }: ram.TradePriceType,
+  parent: XMLElement,
+): void {
+  if (chargeAmount) {
+    convertAmount(chargeAmount, parent.node('ram:ChargeAmount'))
+  }
+  if (basisQuantity) {
+    convertQuantity(basisQuantity, parent.node('ram:BasisQuantity'))
+  }
+  if (appliedTradeAllowanceCharge && appliedTradeAllowanceCharge.length > 0) {
+    appliedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:AppliedTradeAllowanceCharge')))
+  }
+  if (includedTradeTax) {
+    convertTradeTax(includedTradeTax, parent.node('ram:IncludedTradeTax'))
+  }
+}
+
+function convertLineTradeDelivery(
+  {
+    billedQuantity,
+    chargeFreeQuantity,
+    packageQuantity,
+    perPackageUnitQuantity,
+    shipToTradeParty,
+    ultimateShipToTradeParty,
+    actualDeliverySupplyChainEvent,
+    despatchAdviceReferencedDocument,
+    receivingAdviceReferencedDocument,
+    deliveryNoteReferencedDocument,
+  }: ram.LineTradeDeliveryType,
+  parent: XMLElement,
+): void {
+  if (billedQuantity) {
+    convertQuantity(billedQuantity, parent.node('ram:BilledQuantity'))
+  }
+  if (chargeFreeQuantity) {
+    convertQuantity(chargeFreeQuantity, parent.node('ram:ChargeFreeQuantity'))
+  }
+  if (packageQuantity) {
+    convertQuantity(packageQuantity, parent.node('ram:PackageQuantity'))
+  }
+  if (perPackageUnitQuantity) {
+    convertQuantity(perPackageUnitQuantity, parent.node('ram:PerPackageUnitQuantity'))
+  }
+  if (shipToTradeParty) {
+    convertTradeParty(shipToTradeParty, parent.node('ram:ShipToTradeParty'))
+  }
+  if (ultimateShipToTradeParty) {
+    convertTradeParty(ultimateShipToTradeParty, parent.node('ram:UltimateShipToTradeParty'))
+  }
+  if (actualDeliverySupplyChainEvent) {
+    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.node('ram:ActualDeliverySupplyChainEvent'))
+  }
+  if (despatchAdviceReferencedDocument) {
+    convertReferencedDocument(despatchAdviceReferencedDocument, parent.node('ram:DespatchAdviceReferencedDocument'))
+  }
+  if (receivingAdviceReferencedDocument) {
+    convertReferencedDocument(receivingAdviceReferencedDocument, parent.node('ram:ReceivingAdviceReferencedDocument'))
+  }
+  if (deliveryNoteReferencedDocument) {
+    convertReferencedDocument(deliveryNoteReferencedDocument, parent.node('ram:DeliveryNoteReferencedDocument'))
+  }
+}
+
+function convertLineTradeSettlement(
+  {
+    applicableTradeTax,
+    billingSpecifiedPeriod,
+    specifiedTradeAllowanceCharge,
+    specifiedTradeSettlementLineMonetarySummation,
+    invoiceReferencedDocument,
+    additionalReferencedDocument,
+    receivableSpecifiedTradeAccountingAccount,
+  }: ram.LineTradeSettlementType,
+  parent: XMLElement,
+): void {
+  if (applicableTradeTax && applicableTradeTax.length > 0) {
+    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.node('ram:ApplicableTradeTax')))
+  }
+  if (billingSpecifiedPeriod) {
+    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.node('ram:BillingSpecifiedPeriod'))
+  }
+  if (specifiedTradeAllowanceCharge && specifiedTradeAllowanceCharge.length > 0) {
+    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:SpecifiedTradeAllowanceCharge')))
+  }
+  if (specifiedTradeSettlementLineMonetarySummation) {
+    convertTradeSettlementLineMonetarySummation(
+      specifiedTradeSettlementLineMonetarySummation,
+      parent.node('ram:SpecifiedTradeSettlementLineMonetarySummation'),
+    )
+  }
+  if (invoiceReferencedDocument) {
+    convertReferencedDocument(invoiceReferencedDocument, parent.node('ram:InvoiceReferencedDocument'))
+  }
+  if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+  }
+  if (receivableSpecifiedTradeAccountingAccount && receivableSpecifiedTradeAccountingAccount.length > 0) {
+    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.node('ram:ReceivableSpecifiedTradeAccountingAccount')))
+  }
+}
+
+function convertTradeSettlementLineMonetarySummation(
+  { lineTotalAmount, chargeTotalAmount, allowanceTotalAmount, taxTotalAmount, grandTotalAmount, totalAllowanceChargeAmount }: ram.TradeSettlementLineMonetarySummationType,
+  parent: XMLElement,
+): void {
+  if (lineTotalAmount) {
+    convertAmount(lineTotalAmount, parent.node('ram:LineTotalAmount'))
+  }
+  if (chargeTotalAmount) {
+    convertAmount(chargeTotalAmount, parent.node('ram:ChargeTotalAmount'))
+  }
+  if (allowanceTotalAmount) {
+    convertAmount(allowanceTotalAmount, parent.node('ram:AllowanceTotalAmount'))
+  }
+  if (taxTotalAmount) {
+    convertAmount(taxTotalAmount, parent.node('ram:TaxTotalAmount'))
+  }
+  if (grandTotalAmount) {
+    convertAmount(grandTotalAmount, parent.node('ram:GrandTotalAmount'))
+  }
+  if (totalAllowanceChargeAmount) {
+    convertAmount(totalAllowanceChargeAmount, parent.node('ram:TotalAllowanceChargeAmount'))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header trade agreement
+// ---------------------------------------------------------------------------
+
 function convertHeaderTradeAgreement(
   {
     buyerReference,
     sellerTradeParty,
     buyerTradeParty,
-    buyerOrderReferencedDocument,
-    additionalReferencedDocument,
-    applicableTradeDeliveryTerms,
-    buyerAgentTradeParty,
-    buyerTaxRepresentativeTradeParty,
-    contractReferencedDocument,
-    productEndUserTradeParty,
-    quotationReferencedDocument,
     salesAgentTradeParty,
-    sellerOrderReferencedDocument,
+    buyerTaxRepresentativeTradeParty,
     sellerTaxRepresentativeTradeParty,
+    productEndUserTradeParty,
+    applicableTradeDeliveryTerms,
+    sellerOrderReferencedDocument,
+    buyerOrderReferencedDocument,
+    quotationReferencedDocument,
+    contractReferencedDocument,
+    additionalReferencedDocument,
+    buyerAgentTradeParty,
     specifiedProcuringProject,
     ultimateCustomerOrderReferencedDocument,
   }: HeaderTradeAgreementType,
   parent: XMLElement,
 ): void {
   if (buyerReference) {
-    const refEl = parent.node('ram:BuyerReference')
-    convertText(buyerReference, refEl)
+    convertText(buyerReference, parent.node('ram:BuyerReference'))
   }
 
-  // Convert seller party
-  const sellerPartyEl = parent.node('ram:SellerTradeParty')
-  convertTradeParty(sellerTradeParty, sellerPartyEl)
-
-  // Convert buyer party
-  const buyerPartyEl = parent.node('ram:BuyerTradeParty')
-  convertTradeParty(buyerTradeParty, buyerPartyEl)
-
-  // Convert buyer order reference document if available
-  if (buyerOrderReferencedDocument) {
-    const docEl = parent.node('ram:BuyerOrderReferencedDocument')
-
-    if (buyerOrderReferencedDocument.issuerAssignedID) {
-      const idEl = docEl.node('ram:IssuerAssignedID')
-      convertID(buyerOrderReferencedDocument.issuerAssignedID, idEl)
-    }
-  }
-
-  if (additionalReferencedDocument) {
-    additionalReferencedDocument.forEach((doc) => {
-      const docEl = parent.node('ram:AdditionalReferencedDocument')
-      convertReferencedDocument(doc, docEl)
-    })
-  }
-
-  if (applicableTradeDeliveryTerms) {
-    // TODO: implement
-  }
+  convertTradeParty(sellerTradeParty, parent.node('ram:SellerTradeParty'))
+  convertTradeParty(buyerTradeParty, parent.node('ram:BuyerTradeParty'))
 
   if (salesAgentTradeParty) {
-    const agentEl = parent.node('ram:SalesAgentTradeParty')
-    convertTradeParty(salesAgentTradeParty, agentEl)
+    convertTradeParty(salesAgentTradeParty, parent.node('ram:SalesAgentTradeParty'))
   }
-
-  if (buyerAgentTradeParty) {
-    const agentEl = parent.node('ram:BuyerAgentTradeParty')
-    convertTradeParty(buyerAgentTradeParty, agentEl)
-  }
-
   if (buyerTaxRepresentativeTradeParty) {
-    const taxEl = parent.node('ram:BuyerTaxRepresentativeTradeParty')
-    convertTradeParty(buyerTaxRepresentativeTradeParty, taxEl)
+    convertTradeParty(buyerTaxRepresentativeTradeParty, parent.node('ram:BuyerTaxRepresentativeTradeParty'))
   }
-
   if (sellerTaxRepresentativeTradeParty) {
-    const taxEl = parent.node('ram:SellerTaxRepresentativeTradeParty')
-    convertTradeParty(sellerTaxRepresentativeTradeParty, taxEl)
+    convertTradeParty(sellerTaxRepresentativeTradeParty, parent.node('ram:SellerTaxRepresentativeTradeParty'))
   }
-
   if (productEndUserTradeParty) {
-    const endUserEl = parent.node('ram:ProductEndUserTradeParty')
-    convertTradeParty(productEndUserTradeParty, endUserEl)
+    convertTradeParty(productEndUserTradeParty, parent.node('ram:ProductEndUserTradeParty'))
   }
-
-  if (quotationReferencedDocument) {
-    const docEl = parent.node('ram:QuotationReferencedDocument')
-    convertReferencedDocument(quotationReferencedDocument, docEl)
+  if (applicableTradeDeliveryTerms) {
+    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.node('ram:ApplicableTradeDeliveryTerms'))
   }
-
-  if (contractReferencedDocument) {
-    const docEl = parent.node('ram:ContractReferencedDocument')
-    convertReferencedDocument(contractReferencedDocument, docEl)
-  }
-
   if (sellerOrderReferencedDocument) {
-    const docEl = parent.node('ram:SellerOrderReferencedDocument')
-    convertReferencedDocument(sellerOrderReferencedDocument, docEl)
+    convertReferencedDocument(sellerOrderReferencedDocument, parent.node('ram:SellerOrderReferencedDocument'))
   }
-
+  if (buyerOrderReferencedDocument) {
+    convertReferencedDocument(buyerOrderReferencedDocument, parent.node('ram:BuyerOrderReferencedDocument'))
+  }
+  if (quotationReferencedDocument) {
+    convertReferencedDocument(quotationReferencedDocument, parent.node('ram:QuotationReferencedDocument'))
+  }
+  if (contractReferencedDocument) {
+    convertReferencedDocument(contractReferencedDocument, parent.node('ram:ContractReferencedDocument'))
+  }
+  if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+  }
+  if (buyerAgentTradeParty) {
+    convertTradeParty(buyerAgentTradeParty, parent.node('ram:BuyerAgentTradeParty'))
+  }
   if (specifiedProcuringProject) {
-    // @TODO: implement
+    convertProcuringProject(specifiedProcuringProject, parent.node('ram:SpecifiedProcuringProject'))
   }
-
-  if (ultimateCustomerOrderReferencedDocument) {
-    ultimateCustomerOrderReferencedDocument.forEach((doc) => {
-      const docEl = parent.node('ram:UltimateCustomerOrderReferencedDocument')
-      convertReferencedDocument(doc, docEl)
-    })
+  if (ultimateCustomerOrderReferencedDocument && ultimateCustomerOrderReferencedDocument.length > 0) {
+    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:UltimateCustomerOrderReferencedDocument')))
   }
 }
-/**
- * Convert TradePartyType to XML
- */
+
+function convertProcuringProject({ id, name }: ram.ProcuringProjectType, parent: XMLElement): void {
+  convertID(id, parent.node('ram:ID'))
+  convertText(name, parent.node('ram:Name'))
+}
+
+function convertTradeDeliveryTerms({ deliveryTypeCode, relevantTradeLocation }: ram.TradeDeliveryTermsType, parent: XMLElement): void {
+  if (deliveryTypeCode) {
+    parent.node('ram:DeliveryTypeCode', deliveryTypeCode.value)
+  }
+  if (relevantTradeLocation) {
+    const el = parent.node('ram:RelevantTradeLocation')
+    if (relevantTradeLocation.countryID) {
+      el.node('ram:CountryID', relevantTradeLocation.countryID.value)
+    }
+    if (relevantTradeLocation.name) {
+      convertText(relevantTradeLocation.name, el.node('ram:Name'))
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Trade party
+// ---------------------------------------------------------------------------
+
 function convertTradeParty(
   {
-    name,
-    specifiedLegalOrganization,
-    postalTradeAddress,
-    specifiedTaxRegistration,
-    definedTradeContact,
-    description,
-    globalID,
     id,
+    globalID,
+    name,
     roleCode,
+    description,
+    specifiedLegalOrganization,
+    definedTradeContact,
+    postalTradeAddress,
     uriUniversalCommunication,
+    specifiedTaxRegistration,
   }: ram.TradePartyType,
   parent: XMLElement,
 ): void {
+  if (id && id.length > 0) {
+    id.forEach(i => convertID(i, parent.node('ram:ID')))
+  }
+  if (globalID && globalID.length > 0) {
+    globalID.forEach(g => convertID(g, parent.node('ram:GlobalID')))
+  }
   if (name) {
-    const nameEl = parent.node('ram:Name')
-    convertText(name, nameEl)
+    convertText(name, parent.node('ram:Name'))
   }
-
+  if (roleCode) {
+    parent.node('ram:RoleCode', roleCode.value)
+  }
+  if (description) {
+    convertText(description, parent.node('ram:Description'))
+  }
   if (specifiedLegalOrganization) {
-    const orgEl = parent.node('ram:SpecifiedLegalOrganization')
-
-    if (specifiedLegalOrganization.id) {
-      const idEl = orgEl.node('ram:ID')
-      convertID(specifiedLegalOrganization.id, idEl)
-    }
+    convertLegalOrganization(specifiedLegalOrganization, parent.node('ram:SpecifiedLegalOrganization'))
   }
-
+  if (definedTradeContact && definedTradeContact.length > 0) {
+    definedTradeContact.forEach(c => convertTradeContact(c, parent.node('ram:DefinedTradeContact')))
+  }
   if (postalTradeAddress) {
-    const addressEl = parent.node('ram:PostalTradeAddress')
-    convertTradeAddress(postalTradeAddress, addressEl)
+    convertTradeAddress(postalTradeAddress, parent.node('ram:PostalTradeAddress'))
   }
-
+  if (uriUniversalCommunication) {
+    convertUniversalCommunication(uriUniversalCommunication, parent.node('ram:URIUniversalCommunication'))
+  }
   if (specifiedTaxRegistration && specifiedTaxRegistration.length > 0) {
     specifiedTaxRegistration.forEach((tax) => {
       const taxEl = parent.node('ram:SpecifiedTaxRegistration')
-
-      if (tax.id) {
-        const idEl = taxEl.node('ram:ID')
-        convertID(tax.id, idEl)
-      }
+      convertID(tax.id, taxEl.node('ram:ID'))
     })
-  }
-
-  if (definedTradeContact) {
-    // @TODO: implement
-  }
-
-  if (description) {
-    const descriptionEl = parent.node('ram:Description')
-    convertText(description, descriptionEl)
-  }
-
-  if (globalID) {
-    globalID.forEach((id) => {
-      const globalIDEl = parent.node('ram:GlobalID')
-      convertID(id, globalIDEl)
-    })
-  }
-
-  if (id) {
-    // @TODO: implement
-  }
-
-  if (roleCode) {
-    const roleCodeEl = parent.node('ram:RoleCode')
-    convertText(roleCode, roleCodeEl)
-  }
-
-  if (uriUniversalCommunication) {
-    // @TODO: implement
   }
 }
 
-/**
- * Convert TradeAddressType to XML
- */
+function convertLegalOrganization(
+  { id, tradingBusinessName, postalTradeAddress }: ram.LegalOrganizationType,
+  parent: XMLElement,
+): void {
+  if (id) {
+    convertID(id, parent.node('ram:ID'))
+  }
+  if (tradingBusinessName) {
+    convertText(tradingBusinessName, parent.node('ram:TradingBusinessName'))
+  }
+  if (postalTradeAddress) {
+    convertTradeAddress(postalTradeAddress, parent.node('ram:PostalTradeAddress'))
+  }
+}
+
+function convertTradeContact(
+  { personName, departmentName, typeCode, telephoneUniversalCommunication, faxUniversalCommunication, emailURIUniversalCommunication }: ram.TradeContactType,
+  parent: XMLElement,
+): void {
+  if (personName) {
+    convertText(personName, parent.node('ram:PersonName'))
+  }
+  if (departmentName) {
+    convertText(departmentName, parent.node('ram:DepartmentName'))
+  }
+  if (typeCode) {
+    parent.node('ram:TypeCode', typeCode.value)
+  }
+  if (telephoneUniversalCommunication) {
+    convertUniversalCommunication(telephoneUniversalCommunication, parent.node('ram:TelephoneUniversalCommunication'))
+  }
+  if (faxUniversalCommunication) {
+    convertUniversalCommunication(faxUniversalCommunication, parent.node('ram:FaxUniversalCommunication'))
+  }
+  if (emailURIUniversalCommunication) {
+    convertUniversalCommunication(emailURIUniversalCommunication, parent.node('ram:EmailURIUniversalCommunication'))
+  }
+}
+
+function convertUniversalCommunication({ uriID, completeNumber }: ram.UniversalCommunicationType, parent: XMLElement): void {
+  if (uriID) {
+    convertID(uriID, parent.node('ram:URIID'))
+  }
+  if (completeNumber) {
+    convertText(completeNumber, parent.node('ram:CompleteNumber'))
+  }
+}
+
 function convertTradeAddress(
-  { countryID, postcodeCode, cityName, lineOne }: ram.TradeAddressType,
+  { postcodeCode, lineOne, lineTwo, lineThree, cityName, countryID, countrySubDivisionName }: ram.TradeAddressType,
   parent: XMLElement,
 ): void {
   if (postcodeCode) {
-    const postcodeEl = parent.node('ram:PostcodeCode')
-    convertText(postcodeCode, postcodeEl)
+    convertCode(postcodeCode, parent.node('ram:PostcodeCode'))
   }
-
   if (lineOne) {
-    const lineOneEl = parent.node('ram:LineOne')
-    convertText(lineOne, lineOneEl)
+    convertText(lineOne, parent.node('ram:LineOne'))
   }
-
+  if (lineTwo) {
+    convertText(lineTwo, parent.node('ram:LineTwo'))
+  }
+  if (lineThree) {
+    convertText(lineThree, parent.node('ram:LineThree'))
+  }
   if (cityName) {
-    const cityNameEl = parent.node('ram:CityName')
-    convertText(cityName, cityNameEl)
+    convertText(cityName, parent.node('ram:CityName'))
   }
-
-  if (countryID) {
-    const countryIDEl = parent.node('ram:CountryID')
-    countryIDEl.text(countryID.value)
+  parent.node('ram:CountryID', countryID.value)
+  if (countrySubDivisionName && countrySubDivisionName.length > 0) {
+    countrySubDivisionName.forEach(n => convertText(n, parent.node('ram:CountrySubDivisionName')))
   }
 }
 
-/**
- * Convert HeaderTradeDeliveryType to XML
- */
+// ---------------------------------------------------------------------------
+// Header trade delivery
+// ---------------------------------------------------------------------------
+
 function convertHeaderTradeDelivery(
   {
+    relatedSupplyChainConsignment,
     shipToTradeParty,
     ultimateShipToTradeParty,
     shipFromTradeParty,
@@ -545,47 +847,50 @@ function convertHeaderTradeDelivery(
   }: HeaderTradeDeliveryType,
   parent: XMLElement,
 ): void {
-  // Follow the exact sequence order defined in the XSD schema for HeaderTradeDeliveryType
+  if (relatedSupplyChainConsignment) {
+    convertSupplyChainConsignment(relatedSupplyChainConsignment, parent.node('ram:RelatedSupplyChainConsignment'))
+  }
   if (shipToTradeParty) {
-    const shipToEl = parent.node('ram:ShipToTradeParty')
-    convertTradeParty(shipToTradeParty, shipToEl)
+    convertTradeParty(shipToTradeParty, parent.node('ram:ShipToTradeParty'))
   }
-
   if (ultimateShipToTradeParty) {
-    const el = parent.node('ram:UltimateShipToTradeParty')
-    convertTradeParty(ultimateShipToTradeParty, el)
+    convertTradeParty(ultimateShipToTradeParty, parent.node('ram:UltimateShipToTradeParty'))
   }
-
   if (shipFromTradeParty) {
-    const el = parent.node('ram:ShipFromTradeParty')
-    convertTradeParty(shipFromTradeParty, el)
+    convertTradeParty(shipFromTradeParty, parent.node('ram:ShipFromTradeParty'))
   }
-
-  // Actual delivery date (BT-72)
   if (actualDeliverySupplyChainEvent) {
-    const el = parent.node('ram:ActualDeliverySupplyChainEvent')
-    convertSupplyChainEvent(actualDeliverySupplyChainEvent, el)
+    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.node('ram:ActualDeliverySupplyChainEvent'))
   }
-
   if (despatchAdviceReferencedDocument) {
-    const el = parent.node('ram:DespatchAdviceReferencedDocument')
-    convertReferencedDocument(despatchAdviceReferencedDocument, el)
+    convertReferencedDocument(despatchAdviceReferencedDocument, parent.node('ram:DespatchAdviceReferencedDocument'))
   }
-
   if (receivingAdviceReferencedDocument) {
-    const el = parent.node('ram:ReceivingAdviceReferencedDocument')
-    convertReferencedDocument(receivingAdviceReferencedDocument, el)
+    convertReferencedDocument(receivingAdviceReferencedDocument, parent.node('ram:ReceivingAdviceReferencedDocument'))
   }
-
   if (deliveryNoteReferencedDocument) {
-    const el = parent.node('ram:DeliveryNoteReferencedDocument')
-    convertReferencedDocument(deliveryNoteReferencedDocument, el)
+    convertReferencedDocument(deliveryNoteReferencedDocument, parent.node('ram:DeliveryNoteReferencedDocument'))
   }
 }
 
-/**
- * Convert HeaderTradeSettlementType to XML
- */
+function convertSupplyChainConsignment({ specifiedLogisticsTransportMovement }: ram.SupplyChainConsignmentType, parent: XMLElement): void {
+  if (specifiedLogisticsTransportMovement && specifiedLogisticsTransportMovement.length > 0) {
+    specifiedLogisticsTransportMovement.forEach((m) => {
+      parent.node('ram:SpecifiedLogisticsTransportMovement').node('ram:ModeCode', m.modeCode.value)
+    })
+  }
+}
+
+function convertSupplyChainEvent({ occurrenceDateTime }: ram.SupplyChainEventType, parent: XMLElement): void {
+  if (occurrenceDateTime) {
+    convertDateTime(occurrenceDateTime, parent.node('ram:OccurrenceDateTime'))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header trade settlement
+// ---------------------------------------------------------------------------
+
 function convertHeaderTradeSettlement(
   {
     creditorReferenceID,
@@ -597,132 +902,161 @@ function convertHeaderTradeSettlement(
     invoiceeTradeParty,
     payeeTradeParty,
     payerTradeParty,
+    taxApplicableTradeCurrencyExchange,
     specifiedTradeSettlementPaymentMeans,
     applicableTradeTax,
     billingSpecifiedPeriod,
     specifiedTradeAllowanceCharge,
+    specifiedLogisticsServiceCharge,
     specifiedTradePaymentTerms,
     specifiedTradeSettlementHeaderMonetarySummation,
+    specifiedFinancialAdjustment,
+    invoiceReferencedDocument,
+    receivableSpecifiedTradeAccountingAccount,
+    specifiedAdvancePayment,
   }: HeaderTradeSettlementType,
   parent: XMLElement,
 ): void {
-  // Follow the exact sequence order defined in the XSD schema (EXTENDED superset)
   if (creditorReferenceID) {
-    const creditorReferenceIDEl = parent.node('ram:CreditorReferenceID')
-    convertID(creditorReferenceID, creditorReferenceIDEl)
+    convertID(creditorReferenceID, parent.node('ram:CreditorReferenceID'))
   }
-
   if (paymentReference) {
-    const paymentReferenceEl = parent.node('ram:PaymentReference')
-    convertText(paymentReference, paymentReferenceEl)
+    convertText(paymentReference, parent.node('ram:PaymentReference'))
   }
-
   if (taxCurrencyCode) {
-    const taxCurrencyCodeEl = parent.node('ram:TaxCurrencyCode')
-    taxCurrencyCodeEl.text(taxCurrencyCode.value)
+    parent.node('ram:TaxCurrencyCode', taxCurrencyCode.value)
   }
 
-  // Required element
-  const currencyEl = parent.node('ram:InvoiceCurrencyCode')
-  currencyEl.text(invoiceCurrencyCode.value)
+  parent.node('ram:InvoiceCurrencyCode', invoiceCurrencyCode.value)
 
-  // The following four parties only exist in the EXTENDED profile
+  // The following are EXTENDED-only header parties
   if (invoiceIssuerReference) {
-    const invoiceIssuerReferenceEl = parent.node('ram:InvoiceIssuerReference')
-    convertText(invoiceIssuerReference, invoiceIssuerReferenceEl)
+    convertText(invoiceIssuerReference, parent.node('ram:InvoiceIssuerReference'))
   }
-
   if (invoicerTradeParty) {
-    const invoicerEl = parent.node('ram:InvoicerTradeParty')
-    convertTradeParty(invoicerTradeParty, invoicerEl)
+    convertTradeParty(invoicerTradeParty, parent.node('ram:InvoicerTradeParty'))
   }
-
   if (invoiceeTradeParty) {
-    const invoiceeEl = parent.node('ram:InvoiceeTradeParty')
-    convertTradeParty(invoiceeTradeParty, invoiceeEl)
+    convertTradeParty(invoiceeTradeParty, parent.node('ram:InvoiceeTradeParty'))
   }
-
   if (payeeTradeParty) {
-    const payeeEl = parent.node('ram:PayeeTradeParty')
-    convertTradeParty(payeeTradeParty, payeeEl)
+    convertTradeParty(payeeTradeParty, parent.node('ram:PayeeTradeParty'))
   }
-
   if (payerTradeParty) {
-    const payerEl = parent.node('ram:PayerTradeParty')
-    convertTradeParty(payerTradeParty, payerEl)
+    convertTradeParty(payerTradeParty, parent.node('ram:PayerTradeParty'))
+  }
+  if (taxApplicableTradeCurrencyExchange) {
+    convertTradeCurrencyExchange(taxApplicableTradeCurrencyExchange, parent.node('ram:TaxApplicableTradeCurrencyExchange'))
   }
 
-  // Handle the payment means
   if (specifiedTradeSettlementPaymentMeans && specifiedTradeSettlementPaymentMeans.length > 0) {
-    specifiedTradeSettlementPaymentMeans.forEach((paymentMeans) => {
-      const paymentMeansEl = parent.node('ram:SpecifiedTradeSettlementPaymentMeans')
-      // Implementation for payment means would be here
-      if (paymentMeans.typeCode) {
-        const typeCodeEl = paymentMeansEl.node('ram:TypeCode')
-        typeCodeEl.text(paymentMeans.typeCode.value)
-      }
-    })
+    specifiedTradeSettlementPaymentMeans.forEach(pm => convertPaymentMeans(pm, parent.node('ram:SpecifiedTradeSettlementPaymentMeans')))
   }
 
-  // Convert applicable trade tax - required in all profiles
   if (applicableTradeTax && applicableTradeTax.length > 0) {
-    applicableTradeTax.forEach((tax) => {
-      const taxEl = parent.node('ram:ApplicableTradeTax')
-      convertTradeTax(tax, taxEl)
-    })
+    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.node('ram:ApplicableTradeTax')))
   }
 
   if (billingSpecifiedPeriod) {
-    const billingPeriodEl = parent.node('ram:BillingSpecifiedPeriod')
-    convertSpecifiedPeriod(billingSpecifiedPeriod, billingPeriodEl)
+    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.node('ram:BillingSpecifiedPeriod'))
   }
 
   if (specifiedTradeAllowanceCharge && specifiedTradeAllowanceCharge.length > 0) {
-    specifiedTradeAllowanceCharge.forEach((allowanceCharge) => {
-      const allowanceChargeEl = parent.node('ram:SpecifiedTradeAllowanceCharge')
-      convertAllowanceCharge(allowanceCharge, allowanceChargeEl)
-    })
+    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:SpecifiedTradeAllowanceCharge')))
   }
 
-  // Payment terms (BT-20) - previously destructured but never emitted
+  if (specifiedLogisticsServiceCharge && specifiedLogisticsServiceCharge.length > 0) {
+    specifiedLogisticsServiceCharge.forEach(c => convertLogisticsServiceCharge(c, parent.node('ram:SpecifiedLogisticsServiceCharge')))
+  }
+
   if (specifiedTradePaymentTerms && specifiedTradePaymentTerms.length > 0) {
-    specifiedTradePaymentTerms.forEach((terms) => {
-      const termsEl = parent.node('ram:SpecifiedTradePaymentTerms')
-      convertPaymentTerms(terms, termsEl)
-    })
+    specifiedTradePaymentTerms.forEach(t => convertPaymentTerms(t, parent.node('ram:SpecifiedTradePaymentTerms')))
   }
 
-  // Convert monetary summation - required in all profiles
-  const summationEl = parent.node('ram:SpecifiedTradeSettlementHeaderMonetarySummation')
-  convertTradeSettlementHeaderMonetarySummation(specifiedTradeSettlementHeaderMonetarySummation, summationEl)
+  convertTradeSettlementHeaderMonetarySummation(
+    specifiedTradeSettlementHeaderMonetarySummation,
+    parent.node('ram:SpecifiedTradeSettlementHeaderMonetarySummation'),
+  )
+
+  if (specifiedFinancialAdjustment && specifiedFinancialAdjustment.length > 0) {
+    specifiedFinancialAdjustment.forEach(a => convertFinancialAdjustment(a, parent.node('ram:SpecifiedFinancialAdjustment')))
+  }
+
+  if (invoiceReferencedDocument && invoiceReferencedDocument.length > 0) {
+    invoiceReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:InvoiceReferencedDocument')))
+  }
+
+  if (receivableSpecifiedTradeAccountingAccount && receivableSpecifiedTradeAccountingAccount.length > 0) {
+    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.node('ram:ReceivableSpecifiedTradeAccountingAccount')))
+  }
+
+  if (specifiedAdvancePayment && specifiedAdvancePayment.length > 0) {
+    specifiedAdvancePayment.forEach(p => convertAdvancePayment(p, parent.node('ram:SpecifiedAdvancePayment')))
+  }
 }
 
-/**
- * Convert TradePaymentTermsType to XML
- */
-function convertPaymentTerms(
-  { description, dueDateDateTime, directDebitMandateID }: ram.TradePaymentTermsType,
+function convertTradeCurrencyExchange(
+  { sourceCurrencyCode, targetCurrencyCode, conversionRate, conversionRateDateTime }: ram.TradeCurrencyExchangeType,
   parent: XMLElement,
 ): void {
-  if (description) {
-    const el = parent.node('ram:Description')
-    convertText(description, el)
-  }
-
-  if (dueDateDateTime) {
-    const el = parent.node('ram:DueDateDateTime')
-    convertDateTime(dueDateDateTime, el)
-  }
-
-  if (directDebitMandateID) {
-    const el = parent.node('ram:DirectDebitMandateID')
-    convertID(directDebitMandateID, el)
+  parent.node('ram:SourceCurrencyCode', sourceCurrencyCode.value)
+  parent.node('ram:TargetCurrencyCode', targetCurrencyCode.value)
+  parent.node('ram:ConversionRate', String(conversionRate.value))
+  if (conversionRateDateTime) {
+    convertDateTime(conversionRateDateTime, parent.node('ram:ConversionRateDateTime'))
   }
 }
 
-/**
- * Convert TradeTaxType to XML
- */
+function convertPaymentMeans(
+  {
+    typeCode,
+    information,
+    applicableTradeSettlementFinancialCard,
+    payerPartyDebtorFinancialAccount,
+    payeePartyCreditorFinancialAccount,
+    payerSpecifiedDebtorFinancialInstitution,
+    payeeSpecifiedCreditorFinancialInstitution,
+  }: ram.TradeSettlementPaymentMeansType,
+  parent: XMLElement,
+): void {
+  parent.node('ram:TypeCode', typeCode.value)
+  if (information) {
+    convertText(information, parent.node('ram:Information'))
+  }
+  if (applicableTradeSettlementFinancialCard) {
+    const el = parent.node('ram:ApplicableTradeSettlementFinancialCard')
+    convertID(applicableTradeSettlementFinancialCard.id, el.node('ram:ID'))
+    if (applicableTradeSettlementFinancialCard.cardholderName) {
+      convertText(applicableTradeSettlementFinancialCard.cardholderName, el.node('ram:CardholderName'))
+    }
+  }
+  if (payerPartyDebtorFinancialAccount) {
+    const el = parent.node('ram:PayerPartyDebtorFinancialAccount')
+    convertID(payerPartyDebtorFinancialAccount.ibanID, el.node('ram:IBANID'))
+    if (payerPartyDebtorFinancialAccount.accountName) {
+      convertText(payerPartyDebtorFinancialAccount.accountName, el.node('ram:AccountName'))
+    }
+  }
+  if (payeePartyCreditorFinancialAccount) {
+    const el = parent.node('ram:PayeePartyCreditorFinancialAccount')
+    if (payeePartyCreditorFinancialAccount.ibanID) {
+      convertID(payeePartyCreditorFinancialAccount.ibanID, el.node('ram:IBANID'))
+    }
+    if (payeePartyCreditorFinancialAccount.accountName) {
+      convertText(payeePartyCreditorFinancialAccount.accountName, el.node('ram:AccountName'))
+    }
+    if (payeePartyCreditorFinancialAccount.proprietaryID) {
+      convertID(payeePartyCreditorFinancialAccount.proprietaryID, el.node('ram:ProprietaryID'))
+    }
+  }
+  if (payerSpecifiedDebtorFinancialInstitution?.bicID) {
+    parent.node('ram:PayerSpecifiedDebtorFinancialInstitution').node('ram:BICID').text(payerSpecifiedDebtorFinancialInstitution.bicID.value)
+  }
+  if (payeeSpecifiedCreditorFinancialInstitution?.bicID) {
+    convertID(payeeSpecifiedCreditorFinancialInstitution.bicID, parent.node('ram:PayeeSpecifiedCreditorFinancialInstitution').node('ram:BICID'))
+  }
+}
+
 function convertTradeTax(
   {
     calculatedAmount,
@@ -739,446 +1073,265 @@ function convertTradeTax(
   }: ram.TradeTaxType,
   parent: XMLElement,
 ): void {
-  // Follow the exact sequence order defined in the XSD schema for TradeTaxType
   if (calculatedAmount) {
-    const calculatedAmountEl = parent.node('ram:CalculatedAmount')
-    convertAmount(calculatedAmount, calculatedAmountEl)
+    convertAmount(calculatedAmount, parent.node('ram:CalculatedAmount'))
   }
-
   if (typeCode) {
-    const typeCodeEl = parent.node('ram:TypeCode')
-    typeCodeEl.text(typeCode.value)
+    parent.node('ram:TypeCode', typeCode.value)
   }
-
   if (exemptionReason) {
-    const exemptionReasonEl = parent.node('ram:ExemptionReason')
-    convertText(exemptionReason, exemptionReasonEl)
+    convertText(exemptionReason, parent.node('ram:ExemptionReason'))
   }
-
   if (basisAmount) {
-    const basisAmountEl = parent.node('ram:BasisAmount')
-    convertAmount(basisAmount, basisAmountEl)
+    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
   }
-
   if (lineTotalBasisAmount) {
-    const lineTotalBasisAmountEl = parent.node('ram:LineTotalBasisAmount')
-    convertAmount(lineTotalBasisAmount, lineTotalBasisAmountEl)
+    convertAmount(lineTotalBasisAmount, parent.node('ram:LineTotalBasisAmount'))
   }
-
   if (allowanceChargeBasisAmount) {
-    const allowanceChargeBasisAmountEl = parent.node('ram:AllowanceChargeBasisAmount')
-    convertAmount(allowanceChargeBasisAmount, allowanceChargeBasisAmountEl)
+    convertAmount(allowanceChargeBasisAmount, parent.node('ram:AllowanceChargeBasisAmount'))
   }
-
   if (categoryCode) {
-    const categoryCodeEl = parent.node('ram:CategoryCode')
-    categoryCodeEl.text(categoryCode.value)
+    parent.node('ram:CategoryCode', categoryCode.value)
   }
-
   if (exemptionReasonCode) {
-    const exemptionReasonCodeEl = parent.node('ram:ExemptionReasonCode')
-    convertText(exemptionReasonCode, exemptionReasonCodeEl)
+    convertCode(exemptionReasonCode, parent.node('ram:ExemptionReasonCode'))
   }
-
   if (taxPointDate) {
-    const taxPointDateEl = parent.node('ram:TaxPointDate')
-    convertDate(taxPointDate, taxPointDateEl)
+    convertDate(taxPointDate, parent.node('ram:TaxPointDate'))
   }
-
   if (dueDateTypeCode) {
-    const dueDateTypeCodeEl = parent.node('ram:DueDateTypeCode')
-    dueDateTypeCodeEl.text(dueDateTypeCode.value)
+    parent.node('ram:DueDateTypeCode', dueDateTypeCode.value)
   }
-
   if (rateApplicablePercent) {
-    const rateEl = parent.node('ram:RateApplicablePercent')
-    rateEl.text(String(rateApplicablePercent.value))
+    parent.node('ram:RateApplicablePercent', String(rateApplicablePercent.value))
   }
 }
 
-/**
- * Convert TradeSettlementHeaderMonetarySummationType to XML
- */
+function convertAllowanceCharge(
+  {
+    chargeIndicator,
+    sequenceNumeric,
+    calculationPercent,
+    basisAmount,
+    basisQuantity,
+    actualAmount,
+    reasonCode,
+    reason,
+    categoryTradeTax,
+  }: ram.TradeAllowanceChargeType,
+  parent: XMLElement,
+): void {
+  convertIndicator(chargeIndicator, parent.node('ram:ChargeIndicator'))
+  if (sequenceNumeric) {
+    parent.node('ram:SequenceNumeric', String(sequenceNumeric.value))
+  }
+  if (calculationPercent) {
+    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+  }
+  if (basisAmount) {
+    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+  }
+  if (basisQuantity) {
+    convertQuantity(basisQuantity, parent.node('ram:BasisQuantity'))
+  }
+  if (actualAmount) {
+    convertAmount(actualAmount, parent.node('ram:ActualAmount'))
+  }
+  if (reasonCode) {
+    parent.node('ram:ReasonCode', reasonCode.value)
+  }
+  if (reason) {
+    convertText(reason, parent.node('ram:Reason'))
+  }
+  if (categoryTradeTax) {
+    convertTradeTax(categoryTradeTax, parent.node('ram:CategoryTradeTax'))
+  }
+}
+
+function convertLogisticsServiceCharge(
+  { description, appliedAmount, appliedTradeTax }: ram.LogisticsServiceChargeType,
+  parent: XMLElement,
+): void {
+  convertText(description, parent.node('ram:Description'))
+  convertAmount(appliedAmount, parent.node('ram:AppliedAmount'))
+  if (appliedTradeTax && appliedTradeTax.length > 0) {
+    appliedTradeTax.forEach(t => convertTradeTax(t, parent.node('ram:AppliedTradeTax')))
+  }
+}
+
+function convertPaymentTerms(
+  {
+    description,
+    dueDateDateTime,
+    directDebitMandateID,
+    partialPaymentAmount,
+    applicableTradePaymentPenaltyTerms,
+    applicableTradePaymentDiscountTerms,
+    payeeTradeParty,
+  }: ram.TradePaymentTermsType,
+  parent: XMLElement,
+): void {
+  if (description) {
+    convertText(description, parent.node('ram:Description'))
+  }
+  if (dueDateDateTime) {
+    convertDateTime(dueDateDateTime, parent.node('ram:DueDateDateTime'))
+  }
+  if (directDebitMandateID) {
+    convertID(directDebitMandateID, parent.node('ram:DirectDebitMandateID'))
+  }
+  if (partialPaymentAmount) {
+    convertAmount(partialPaymentAmount, parent.node('ram:PartialPaymentAmount'))
+  }
+  if (applicableTradePaymentPenaltyTerms) {
+    convertPaymentPenaltyTerms(applicableTradePaymentPenaltyTerms, parent.node('ram:ApplicableTradePaymentPenaltyTerms'))
+  }
+  if (applicableTradePaymentDiscountTerms) {
+    convertPaymentDiscountTerms(applicableTradePaymentDiscountTerms, parent.node('ram:ApplicableTradePaymentDiscountTerms'))
+  }
+  if (payeeTradeParty) {
+    convertTradeParty(payeeTradeParty, parent.node('ram:PayeeTradeParty'))
+  }
+}
+
+function convertPaymentPenaltyTerms(
+  { basisDateTime, basisPeriodMeasure, basisAmount, calculationPercent, actualPenaltyAmount }: ram.TradePaymentPenaltyTermsType,
+  parent: XMLElement,
+): void {
+  if (basisDateTime) {
+    convertDateTime(basisDateTime, parent.node('ram:BasisDateTime'))
+  }
+  if (basisPeriodMeasure) {
+    convertMeasure(basisPeriodMeasure, parent.node('ram:BasisPeriodMeasure'))
+  }
+  if (basisAmount) {
+    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+  }
+  if (calculationPercent) {
+    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+  }
+  if (actualPenaltyAmount) {
+    convertAmount(actualPenaltyAmount, parent.node('ram:ActualPenaltyAmount'))
+  }
+}
+
+function convertPaymentDiscountTerms(
+  { basisDateTime, basisPeriodMeasure, basisAmount, calculationPercent, actualDiscountAmount }: ram.TradePaymentDiscountTermsType,
+  parent: XMLElement,
+): void {
+  if (basisDateTime) {
+    convertDateTime(basisDateTime, parent.node('ram:BasisDateTime'))
+  }
+  if (basisPeriodMeasure) {
+    convertMeasure(basisPeriodMeasure, parent.node('ram:BasisPeriodMeasure'))
+  }
+  if (basisAmount) {
+    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+  }
+  if (calculationPercent) {
+    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+  }
+  if (actualDiscountAmount) {
+    convertAmount(actualDiscountAmount, parent.node('ram:ActualDiscountAmount'))
+  }
+}
+
 function convertTradeSettlementHeaderMonetarySummation(
   {
     lineTotalAmount,
+    chargeTotalAmount,
+    allowanceTotalAmount,
     taxBasisTotalAmount,
     taxTotalAmount,
-    grandTotalAmount,
-    duePayableAmount,
-    allowanceTotalAmount,
-    chargeTotalAmount,
     roundingAmount,
+    grandTotalAmount,
     totalPrepaidAmount,
+    duePayableAmount,
   }: ram.TradeSettlementHeaderMonetarySummationType,
   parent: XMLElement,
 ): void {
   if (lineTotalAmount) {
-    const lineTotalEl = parent.node('ram:LineTotalAmount')
-    convertAmount(lineTotalAmount, lineTotalEl)
+    convertAmount(lineTotalAmount, parent.node('ram:LineTotalAmount'))
   }
-
   if (chargeTotalAmount) {
-    const chargeTotalEl = parent.node('ram:ChargeTotalAmount')
-    convertAmount(chargeTotalAmount, chargeTotalEl)
+    convertAmount(chargeTotalAmount, parent.node('ram:ChargeTotalAmount'))
   }
-
   if (allowanceTotalAmount) {
-    const allowanceTotalEl = parent.node('ram:AllowanceTotalAmount')
-    convertAmount(allowanceTotalAmount, allowanceTotalEl)
+    convertAmount(allowanceTotalAmount, parent.node('ram:AllowanceTotalAmount'))
   }
-
-  if (taxBasisTotalAmount && taxBasisTotalAmount.length > 0) {
-    taxBasisTotalAmount.forEach((amount) => {
-      const taxBasisEl = parent.node('ram:TaxBasisTotalAmount')
-      convertAmount(amount, taxBasisEl)
-    })
-  }
-
+  convertAmount(taxBasisTotalAmount, parent.node('ram:TaxBasisTotalAmount'))
   if (taxTotalAmount && taxTotalAmount.length > 0) {
-    taxTotalAmount.forEach((amount) => {
-      const taxTotalEl = parent.node('ram:TaxTotalAmount')
-      convertAmount(amount, taxTotalEl)
-    })
+    taxTotalAmount.forEach(a => convertAmount(a, parent.node('ram:TaxTotalAmount')))
   }
-
   if (roundingAmount) {
-    const roundingEl = parent.node('ram:RoundingAmount')
-    convertAmount(roundingAmount, roundingEl)
+    convertAmount(roundingAmount, parent.node('ram:RoundingAmount'))
   }
-
-  if (grandTotalAmount && grandTotalAmount.length > 0) {
-    grandTotalAmount.forEach((amount) => {
-      const grandTotalEl = parent.node('ram:GrandTotalAmount')
-      convertAmount(amount, grandTotalEl)
-    })
-  }
-
+  convertAmount(grandTotalAmount, parent.node('ram:GrandTotalAmount'))
   if (totalPrepaidAmount) {
-    const totalPrepaidEl = parent.node('ram:TotalPrepaidAmount')
-    convertAmount(totalPrepaidAmount, totalPrepaidEl)
+    convertAmount(totalPrepaidAmount, parent.node('ram:TotalPrepaidAmount'))
   }
+  convertAmount(duePayableAmount, parent.node('ram:DuePayableAmount'))
+}
 
-  if (duePayableAmount) {
-    const duePayableEl = parent.node('ram:DuePayableAmount')
-    convertAmount(duePayableAmount, duePayableEl)
+function convertFinancialAdjustment({ reason, actualAmount }: ram.FinancialAdjustmentType, parent: XMLElement): void {
+  convertText(reason, parent.node('ram:Reason'))
+  convertAmount(actualAmount, parent.node('ram:ActualAmount'))
+}
+
+function convertTradeAccountingAccount({ id, typeCode }: ram.TradeAccountingAccountType, parent: XMLElement): void {
+  convertID(id, parent.node('ram:ID'))
+  if (typeCode) {
+    parent.node('ram:TypeCode', typeCode.value)
   }
 }
 
-/**
- * Convert LineTradeAgreementType to XML
- */
-function convertLineTradeAgreement(
-  {
-    buyerOrderReferencedDocument,
-    quotationReferencedDocument,
-    contractReferencedDocument,
-    additionalReferencedDocument,
-    grossPriceProductTradePrice,
-    netPriceProductTradePrice,
-    ultimateCustomerOrderReferencedDocument,
-  }: ram.LineTradeAgreementType,
+function convertAdvancePayment(
+  { paidAmount, formattedReceivedDateTime, includedTradeTax, invoiceSpecifiedReferencedDocument }: ram.AdvancePaymentType,
   parent: XMLElement,
 ): void {
-  if (buyerOrderReferencedDocument) {
-    const docEl = parent.node('ram:BuyerOrderReferencedDocument')
-    convertReferencedDocument(buyerOrderReferencedDocument, docEl)
+  convertAmount(paidAmount, parent.node('ram:PaidAmount'))
+  if (formattedReceivedDateTime) {
+    convertFormattedDateTime(formattedReceivedDateTime, parent.node('ram:FormattedReceivedDateTime'))
   }
-
-  if (quotationReferencedDocument) {
-    const docEl = parent.node('ram:QuotationReferencedDocument')
-    convertReferencedDocument(quotationReferencedDocument, docEl)
+  if (includedTradeTax && includedTradeTax.length > 0) {
+    includedTradeTax.forEach(t => convertTradeTax(t, parent.node('ram:IncludedTradeTax')))
   }
-
-  if (contractReferencedDocument) {
-    const docEl = parent.node('ram:ContractReferencedDocument')
-    convertReferencedDocument(contractReferencedDocument, docEl)
-  }
-
-  if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
-    additionalReferencedDocument.forEach((doc) => {
-      const docEl = parent.node('ram:AdditionalReferencedDocument')
-      convertReferencedDocument(doc, docEl)
-    })
-  }
-
-  if (grossPriceProductTradePrice) {
-    const priceEl = parent.node('ram:GrossPriceProductTradePrice')
-    convertTradePrice(grossPriceProductTradePrice, priceEl)
-  }
-
-  const netPriceEl = parent.node('ram:NetPriceProductTradePrice')
-  convertTradePrice(netPriceProductTradePrice, netPriceEl)
-
-  if (ultimateCustomerOrderReferencedDocument && ultimateCustomerOrderReferencedDocument.length > 0) {
-    ultimateCustomerOrderReferencedDocument.forEach((doc) => {
-      const docEl = parent.node('ram:UltimateCustomerOrderReferencedDocument')
-      convertReferencedDocument(doc, docEl)
-    })
+  if (invoiceSpecifiedReferencedDocument) {
+    convertReferencedDocument(invoiceSpecifiedReferencedDocument, parent.node('ram:InvoiceSpecifiedReferencedDocument'))
   }
 }
 
-/**
- * Convert ReferencedDocumentType to XML
- */
+// ---------------------------------------------------------------------------
+// Referenced document (shared)
+// ---------------------------------------------------------------------------
+
 function convertReferencedDocument(
-  { issuerAssignedID, lineID }: ram.ReferencedDocumentType,
+  { issuerAssignedID, uriID, lineID, typeCode, name, attachmentBinaryObject, referenceTypeCode, formattedIssueDateTime }: ram.ReferencedDocumentType,
   parent: XMLElement,
 ): void {
   if (issuerAssignedID) {
-    const idEl = parent.node('ram:IssuerAssignedID')
-    convertID(issuerAssignedID, idEl)
+    convertID(issuerAssignedID, parent.node('ram:IssuerAssignedID'))
   }
-
+  if (uriID) {
+    convertID(uriID, parent.node('ram:URIID'))
+  }
   if (lineID) {
-    const idEl = parent.node('ram:LineID')
-    convertID(lineID, idEl)
+    convertID(lineID, parent.node('ram:LineID'))
   }
-}
-
-/**
- * Convert TradePriceType to XML
- */
-function convertTradePrice(
-  { chargeAmount, basisQuantity }: ram.TradePriceType,
-  parent: XMLElement,
-): void {
-  if (chargeAmount) {
-    const amountEl = parent.node('ram:ChargeAmount')
-    convertAmount(chargeAmount, amountEl)
+  if (typeCode) {
+    parent.node('ram:TypeCode', typeCode.value)
   }
-
-  if (basisQuantity) {
-    const quantityEl = parent.node('ram:BasisQuantity')
-    convertQuantity(basisQuantity, quantityEl)
+  if (name && name.length > 0) {
+    name.forEach(n => convertText(n, parent.node('ram:Name')))
   }
-}
-
-/**
- * Convert QuantityType to XML
- */
-function convertQuantity(
-  { value, unitCode }: udt.QuantityType,
-  parent: XMLElement,
-): void {
-  parent.text(String(value))
-
-  if (unitCode) {
-    parent.attr({ unitCode })
+  if (attachmentBinaryObject) {
+    convertBinaryObject(attachmentBinaryObject, parent.node('ram:AttachmentBinaryObject'))
   }
-}
-
-/**
- * Convert TradeAllowanceChargeType to XML
- */
-function convertAllowanceCharge(
-  { chargeIndicator, actualAmount, reasonCode, reason }: ram.TradeAllowanceChargeType,
-  parent: XMLElement,
-): void {
-  if (chargeIndicator) {
-    const indicatorEl = parent.node('ram:ChargeIndicator')
-    convertIndicator(chargeIndicator, indicatorEl)
+  if (referenceTypeCode) {
+    parent.node('ram:ReferenceTypeCode', referenceTypeCode.value)
   }
-
-  if (actualAmount) {
-    const amountEl = parent.node('ram:ActualAmount')
-    convertAmount(actualAmount, amountEl)
-  }
-
-  if (reasonCode) {
-    const codeEl = parent.node('ram:ReasonCode')
-    convertText(reasonCode, codeEl)
-  }
-
-  if (reason) {
-    const reasonEl = parent.node('ram:Reason')
-    convertText(reason, reasonEl)
-  }
-}
-
-/**
- * Convert LineTradeDeliveryType to XML
- */
-function convertLineTradeDelivery(
-  {
-    billedQuantity,
-    chargeFreeQuantity,
-    packageQuantity,
-    shipToTradeParty,
-    ultimateShipToTradeParty,
-    actualDeliverySupplyChainEvent,
-    despatchAdviceReferencedDocument,
-    receivingAdviceReferencedDocument,
-    deliveryNoteReferencedDocument,
-  }: ram.LineTradeDeliveryType,
-  parent: XMLElement,
-): void {
-  const billedQuantityEl = parent.node('ram:BilledQuantity')
-  convertQuantity(billedQuantity, billedQuantityEl)
-
-  if (chargeFreeQuantity) {
-    const quantityEl = parent.node('ram:ChargeFreeQuantity')
-    convertQuantity(chargeFreeQuantity, quantityEl)
-  }
-
-  if (packageQuantity) {
-    const quantityEl = parent.node('ram:PackageQuantity')
-    convertQuantity(packageQuantity, quantityEl)
-  }
-
-  if (shipToTradeParty) {
-    const partyEl = parent.node('ram:ShipToTradeParty')
-    convertTradeParty(shipToTradeParty, partyEl)
-  }
-
-  if (ultimateShipToTradeParty) {
-    const partyEl = parent.node('ram:UltimateShipToTradeParty')
-    convertTradeParty(ultimateShipToTradeParty, partyEl)
-  }
-
-  if (actualDeliverySupplyChainEvent) {
-    const eventEl = parent.node('ram:ActualDeliverySupplyChainEvent')
-    convertSupplyChainEvent(actualDeliverySupplyChainEvent, eventEl)
-  }
-
-  if (despatchAdviceReferencedDocument) {
-    const docEl = parent.node('ram:DespatchAdviceReferencedDocument')
-    convertReferencedDocument(despatchAdviceReferencedDocument, docEl)
-  }
-
-  if (receivingAdviceReferencedDocument) {
-    const docEl = parent.node('ram:ReceivingAdviceReferencedDocument')
-    convertReferencedDocument(receivingAdviceReferencedDocument, docEl)
-  }
-
-  if (deliveryNoteReferencedDocument) {
-    const docEl = parent.node('ram:DeliveryNoteReferencedDocument')
-    convertReferencedDocument(deliveryNoteReferencedDocument, docEl)
-  }
-}
-
-/**
- * Convert SupplyChainEventType to XML
- */
-function convertSupplyChainEvent(
-  { occurrenceDateTime }: ram.SupplyChainEventType,
-  parent: XMLElement,
-): void {
-  if (occurrenceDateTime) {
-    const dateTimeEl = parent.node('ram:OccurrenceDateTime')
-    convertDateTime(occurrenceDateTime, dateTimeEl)
-  }
-}
-
-/**
- * Convert LineTradeSettlementType to XML
- */
-function convertLineTradeSettlement(
-  {
-    applicableTradeTax,
-    billingSpecifiedPeriod,
-    specifiedTradeAllowanceCharge,
-    specifiedTradeSettlementLineMonetarySummation,
-    invoiceReferencedDocument,
-    additionalReferencedDocument,
-    receivableSpecifiedTradeAccountingAccount,
-  }: ram.LineTradeSettlementType,
-  parent: XMLElement,
-): void {
-  if (applicableTradeTax && applicableTradeTax.length > 0) {
-    applicableTradeTax.forEach((tax) => {
-      const taxEl = parent.node('ram:ApplicableTradeTax')
-      convertTradeTax(tax, taxEl)
-    })
-  }
-
-  if (billingSpecifiedPeriod) {
-    const periodEl = parent.node('ram:BillingSpecifiedPeriod')
-    convertSpecifiedPeriod(billingSpecifiedPeriod, periodEl)
-  }
-
-  if (specifiedTradeAllowanceCharge && specifiedTradeAllowanceCharge.length > 0) {
-    specifiedTradeAllowanceCharge.forEach((charge) => {
-      const chargeEl = parent.node('ram:SpecifiedTradeAllowanceCharge')
-      convertAllowanceCharge(charge, chargeEl)
-    })
-  }
-
-  const summationEl = parent.node('ram:SpecifiedTradeSettlementLineMonetarySummation')
-  convertTradeSettlementLineMonetarySummation(specifiedTradeSettlementLineMonetarySummation, summationEl)
-
-  if (invoiceReferencedDocument) {
-    const docEl = parent.node('ram:InvoiceReferencedDocument')
-    convertReferencedDocument(invoiceReferencedDocument, docEl)
-  }
-
-  if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
-    additionalReferencedDocument.forEach((doc) => {
-      const docEl = parent.node('ram:AdditionalReferencedDocument')
-      convertReferencedDocument(doc, docEl)
-    })
-  }
-
-  if (receivableSpecifiedTradeAccountingAccount) {
-    const accountEl = parent.node('ram:ReceivableSpecifiedTradeAccountingAccount')
-    convertTradeAccountingAccount(receivableSpecifiedTradeAccountingAccount, accountEl)
-  }
-}
-
-/**
- * Convert TradeSettlementLineMonetarySummationType to XML
- */
-function convertTradeSettlementLineMonetarySummation(
-  {
-    lineTotalAmount,
-    chargeTotalAmount,
-    allowanceTotalAmount,
-    taxTotalAmount,
-    grandTotalAmount,
-    totalAllowanceChargeAmount,
-  }: ram.TradeSettlementLineMonetarySummationType,
-  parent: XMLElement,
-): void {
-  if (lineTotalAmount) {
-    const amountEl = parent.node('ram:LineTotalAmount')
-    convertAmount(lineTotalAmount, amountEl)
-  }
-
-  if (chargeTotalAmount) {
-    const amountEl = parent.node('ram:ChargeTotalAmount')
-    convertAmount(chargeTotalAmount, amountEl)
-  }
-
-  if (allowanceTotalAmount) {
-    const amountEl = parent.node('ram:AllowanceTotalAmount')
-    convertAmount(allowanceTotalAmount, amountEl)
-  }
-
-  if (taxTotalAmount) {
-    const amountEl = parent.node('ram:TaxTotalAmount')
-    convertAmount(taxTotalAmount, amountEl)
-  }
-
-  if (grandTotalAmount) {
-    const amountEl = parent.node('ram:GrandTotalAmount')
-    convertAmount(grandTotalAmount, amountEl)
-  }
-
-  if (totalAllowanceChargeAmount) {
-    const amountEl = parent.node('ram:TotalAllowanceChargeAmount')
-    convertAmount(totalAllowanceChargeAmount, amountEl)
-  }
-}
-
-/**
- * Convert TradeAccountingAccountType to XML
- */
-function convertTradeAccountingAccount(
-  { id }: ram.TradeAccountingAccountType,
-  parent: XMLElement,
-): void {
-  if (id) {
-    const idEl = parent.node('ram:ID')
-    convertID(id, idEl)
+  if (formattedIssueDateTime) {
+    convertFormattedDateTime(formattedIssueDateTime, parent.node('ram:FormattedIssueDateTime'))
   }
 }

--- a/src/lib/converters/facturx.ts
+++ b/src/lib/converters/facturx.ts
@@ -1050,7 +1050,7 @@ function convertPaymentMeans(
     }
   }
   if (payerSpecifiedDebtorFinancialInstitution?.bicID) {
-    parent.node('ram:PayerSpecifiedDebtorFinancialInstitution').node('ram:BICID').text(payerSpecifiedDebtorFinancialInstitution.bicID.value)
+    convertID(payerSpecifiedDebtorFinancialInstitution.bicID, parent.node('ram:PayerSpecifiedDebtorFinancialInstitution').node('ram:BICID'))
   }
   if (payeeSpecifiedCreditorFinancialInstitution?.bicID) {
     convertID(payeeSpecifiedCreditorFinancialInstitution.bicID, parent.node('ram:PayeeSpecifiedCreditorFinancialInstitution').node('ram:BICID'))

--- a/src/lib/models/facturx/crossIndustryInvoice.ts
+++ b/src/lib/models/facturx/crossIndustryInvoice.ts
@@ -213,6 +213,7 @@ export class HeaderTradeSettlementType {
     specifiedLogisticsServiceCharge,
     specifiedTradePaymentTerms,
     specifiedTradeSettlementHeaderMonetarySummation,
+    specifiedFinancialAdjustment,
     invoiceReferencedDocument,
     receivableSpecifiedTradeAccountingAccount,
     specifiedAdvancePayment,
@@ -234,7 +235,8 @@ export class HeaderTradeSettlementType {
     specifiedLogisticsServiceCharge?: ram.LogisticsServiceChargeType[]
     specifiedTradePaymentTerms?: ram.TradePaymentTermsType[]
     specifiedTradeSettlementHeaderMonetarySummation: ram.TradeSettlementHeaderMonetarySummationType
-    invoiceReferencedDocument?: ram.ReferencedDocumentType
+    specifiedFinancialAdjustment?: ram.FinancialAdjustmentType[]
+    invoiceReferencedDocument?: ram.ReferencedDocumentType[]
     receivableSpecifiedTradeAccountingAccount?: ram.TradeAccountingAccountType[]
     specifiedAdvancePayment?: ram.AdvancePaymentType[]
   }) {
@@ -255,6 +257,7 @@ export class HeaderTradeSettlementType {
     this.specifiedLogisticsServiceCharge = specifiedLogisticsServiceCharge
     this.specifiedTradePaymentTerms = specifiedTradePaymentTerms
     this.specifiedTradeSettlementHeaderMonetarySummation = specifiedTradeSettlementHeaderMonetarySummation
+    this.specifiedFinancialAdjustment = specifiedFinancialAdjustment
     this.invoiceReferencedDocument = invoiceReferencedDocument
     this.receivableSpecifiedTradeAccountingAccount = receivableSpecifiedTradeAccountingAccount
     this.specifiedAdvancePayment = specifiedAdvancePayment
@@ -277,7 +280,8 @@ export class HeaderTradeSettlementType {
   specifiedLogisticsServiceCharge?: ram.LogisticsServiceChargeType[]
   specifiedTradePaymentTerms?: ram.TradePaymentTermsType[]
   specifiedTradeSettlementHeaderMonetarySummation: ram.TradeSettlementHeaderMonetarySummationType
-  invoiceReferencedDocument?: ram.ReferencedDocumentType
+  specifiedFinancialAdjustment?: ram.FinancialAdjustmentType[]
+  invoiceReferencedDocument?: ram.ReferencedDocumentType[]
   receivableSpecifiedTradeAccountingAccount?: ram.TradeAccountingAccountType[]
   specifiedAdvancePayment?: ram.AdvancePaymentType[]
 }

--- a/src/lib/models/facturx/reusableTypes.ts
+++ b/src/lib/models/facturx/reusableTypes.ts
@@ -82,13 +82,36 @@ export class ReferencedDocumentType {
 export class TradeDeliveryTermsType {
   constructor({
     deliveryTypeCode,
+    relevantTradeLocation,
   }: {
     deliveryTypeCode: qdt.DeliveryTermsCodeType
+    relevantTradeLocation?: TradeLocationType
   }) {
     this.deliveryTypeCode = deliveryTypeCode
+    this.relevantTradeLocation = relevantTradeLocation
   }
 
   deliveryTypeCode: qdt.DeliveryTermsCodeType
+  relevantTradeLocation?: TradeLocationType
+}
+
+/**
+ * Trade location type (EXTENDED)
+ */
+export class TradeLocationType {
+  constructor({
+    countryID,
+    name,
+  }: {
+    countryID?: qdt.CountryIDType
+    name?: udt.TextType
+  }) {
+    this.countryID = countryID
+    this.name = name
+  }
+
+  countryID?: qdt.CountryIDType
+  name?: udt.TextType
 }
 
 /**
@@ -118,19 +141,42 @@ export class AdvancePaymentType {
     paidAmount,
     formattedReceivedDateTime,
     includedTradeTax,
+    invoiceSpecifiedReferencedDocument,
   }: {
     paidAmount: udt.AmountType
     formattedReceivedDateTime?: qdt.FormattedDateTimeType
     includedTradeTax: TradeTaxType[]
+    invoiceSpecifiedReferencedDocument?: ReferencedDocumentType
   }) {
     this.paidAmount = paidAmount
     this.formattedReceivedDateTime = formattedReceivedDateTime
     this.includedTradeTax = includedTradeTax
+    this.invoiceSpecifiedReferencedDocument = invoiceSpecifiedReferencedDocument
   }
 
   paidAmount: udt.AmountType
   formattedReceivedDateTime?: qdt.FormattedDateTimeType
   includedTradeTax: TradeTaxType[]
+  invoiceSpecifiedReferencedDocument?: ReferencedDocumentType
+}
+
+/**
+ * Financial adjustment type (EXTENDED)
+ */
+export class FinancialAdjustmentType {
+  constructor({
+    reason,
+    actualAmount,
+  }: {
+    reason: udt.TextType
+    actualAmount: udt.AmountType
+  }) {
+    this.reason = reason
+    this.actualAmount = actualAmount
+  }
+
+  reason: udt.TextType
+  actualAmount: udt.AmountType
 }
 
 /**
@@ -171,11 +217,24 @@ export class CreditorFinancialInstitutionType {
  * Debtor financial account type
  */
 export class DebtorFinancialAccountType {
-  constructor({ ibanID }: { ibanID: udt.IDType }) {
+  constructor({ ibanID, accountName }: { ibanID: udt.IDType, accountName?: udt.TextType }) {
     this.ibanID = ibanID
+    this.accountName = accountName
   }
 
   ibanID: udt.IDType
+  accountName?: udt.TextType
+}
+
+/**
+ * Debtor financial institution type (EXTENDED)
+ */
+export class DebtorFinancialInstitutionType {
+  constructor({ bicID }: { bicID?: udt.IDType }) {
+    this.bicID = bicID
+  }
+
+  bicID?: udt.IDType
 }
 
 /**
@@ -767,6 +826,7 @@ export class TradeSettlementPaymentMeansType {
     applicableTradeSettlementFinancialCard,
     payerPartyDebtorFinancialAccount,
     payeePartyCreditorFinancialAccount,
+    payerSpecifiedDebtorFinancialInstitution,
     payeeSpecifiedCreditorFinancialInstitution,
   }: {
     typeCode: qdt.PaymentMeansCodeType
@@ -774,6 +834,7 @@ export class TradeSettlementPaymentMeansType {
     applicableTradeSettlementFinancialCard?: TradeSettlementFinancialCardType
     payerPartyDebtorFinancialAccount?: DebtorFinancialAccountType
     payeePartyCreditorFinancialAccount?: CreditorFinancialAccountType
+    payerSpecifiedDebtorFinancialInstitution?: DebtorFinancialInstitutionType
     payeeSpecifiedCreditorFinancialInstitution?: CreditorFinancialInstitutionType
   }) {
     this.typeCode = typeCode
@@ -781,6 +842,7 @@ export class TradeSettlementPaymentMeansType {
     this.applicableTradeSettlementFinancialCard = applicableTradeSettlementFinancialCard
     this.payerPartyDebtorFinancialAccount = payerPartyDebtorFinancialAccount
     this.payeePartyCreditorFinancialAccount = payeePartyCreditorFinancialAccount
+    this.payerSpecifiedDebtorFinancialInstitution = payerSpecifiedDebtorFinancialInstitution
     this.payeeSpecifiedCreditorFinancialInstitution = payeeSpecifiedCreditorFinancialInstitution
   }
 
@@ -789,6 +851,7 @@ export class TradeSettlementPaymentMeansType {
   applicableTradeSettlementFinancialCard?: TradeSettlementFinancialCardType
   payerPartyDebtorFinancialAccount?: DebtorFinancialAccountType
   payeePartyCreditorFinancialAccount?: CreditorFinancialAccountType
+  payerSpecifiedDebtorFinancialInstitution?: DebtorFinancialInstitutionType
   payeeSpecifiedCreditorFinancialInstitution?: CreditorFinancialInstitutionType
 }
 
@@ -810,10 +873,10 @@ export class TradeSettlementHeaderMonetarySummationType {
     lineTotalAmount?: udt.AmountType
     chargeTotalAmount?: udt.AmountType
     allowanceTotalAmount?: udt.AmountType
-    taxBasisTotalAmount: udt.AmountType[]
+    taxBasisTotalAmount: udt.AmountType
     taxTotalAmount?: udt.AmountType[]
     roundingAmount?: udt.AmountType
-    grandTotalAmount: udt.AmountType[]
+    grandTotalAmount: udt.AmountType
     totalPrepaidAmount?: udt.AmountType
     duePayableAmount: udt.AmountType
   }) {
@@ -831,10 +894,12 @@ export class TradeSettlementHeaderMonetarySummationType {
   lineTotalAmount?: udt.AmountType
   chargeTotalAmount?: udt.AmountType
   allowanceTotalAmount?: udt.AmountType
-  taxBasisTotalAmount: udt.AmountType[]
+  // 1.09: TaxBasisTotalAmount (BT-109) is single & required; TaxTotalAmount (BT-110/111) is 0..2
+  taxBasisTotalAmount: udt.AmountType
   taxTotalAmount?: udt.AmountType[]
   roundingAmount?: udt.AmountType
-  grandTotalAmount: udt.AmountType[]
+  // 1.09: GrandTotalAmount (BT-112) is single & required
+  grandTotalAmount: udt.AmountType
   totalPrepaidAmount?: udt.AmountType
   duePayableAmount: udt.AmountType
 }
@@ -971,36 +1036,54 @@ export class TradeProductType {
     globalID,
     sellerAssignedID,
     buyerAssignedID,
+    industryAssignedID,
+    modelID,
     name,
     description,
+    batchID,
+    brandName,
+    modelName,
     applicableProductCharacteristic,
     designatedProductClassification,
     individualTradeProductInstance,
     originTradeCountry,
+    manufacturerTradeParty,
     includedReferencedProduct,
   }: {
     id?: udt.IDType
     globalID?: udt.IDType
     sellerAssignedID?: udt.IDType
     buyerAssignedID?: udt.IDType
+    industryAssignedID?: udt.IDType
+    modelID?: udt.IDType
     name: udt.TextType
     description?: udt.TextType
+    batchID?: udt.IDType[]
+    brandName?: udt.TextType
+    modelName?: udt.TextType
     applicableProductCharacteristic?: ProductCharacteristicType[]
     designatedProductClassification?: ProductClassificationType[]
     individualTradeProductInstance?: TradeProductInstanceType[]
     originTradeCountry?: TradeCountryType
+    manufacturerTradeParty?: TradePartyType
     includedReferencedProduct?: ReferencedProductType[]
   }) {
     this.id = id
     this.globalID = globalID
     this.sellerAssignedID = sellerAssignedID
     this.buyerAssignedID = buyerAssignedID
+    this.industryAssignedID = industryAssignedID
+    this.modelID = modelID
     this.name = name
     this.description = description
+    this.batchID = batchID
+    this.brandName = brandName
+    this.modelName = modelName
     this.applicableProductCharacteristic = applicableProductCharacteristic
     this.designatedProductClassification = designatedProductClassification
     this.individualTradeProductInstance = individualTradeProductInstance
     this.originTradeCountry = originTradeCountry
+    this.manufacturerTradeParty = manufacturerTradeParty
     this.includedReferencedProduct = includedReferencedProduct
   }
 
@@ -1008,12 +1091,18 @@ export class TradeProductType {
   globalID?: udt.IDType
   sellerAssignedID?: udt.IDType
   buyerAssignedID?: udt.IDType
+  industryAssignedID?: udt.IDType
+  modelID?: udt.IDType
   name: udt.TextType
   description?: udt.TextType
+  batchID?: udt.IDType[]
+  brandName?: udt.TextType
+  modelName?: udt.TextType
   applicableProductCharacteristic?: ProductCharacteristicType[]
   designatedProductClassification?: ProductClassificationType[]
   individualTradeProductInstance?: TradeProductInstanceType[]
   originTradeCountry?: TradeCountryType
+  manufacturerTradeParty?: TradePartyType
   includedReferencedProduct?: ReferencedProductType[]
 }
 
@@ -1049,37 +1138,49 @@ export class TradePriceType {
  */
 export class LineTradeAgreementType {
   constructor({
+    applicableTradeDeliveryTerms,
+    sellerOrderReferencedDocument,
     buyerOrderReferencedDocument,
     quotationReferencedDocument,
     contractReferencedDocument,
     additionalReferencedDocument,
     grossPriceProductTradePrice,
     netPriceProductTradePrice,
+    itemSellerTradeParty,
     ultimateCustomerOrderReferencedDocument,
   }: {
+    applicableTradeDeliveryTerms?: TradeDeliveryTermsType
+    sellerOrderReferencedDocument?: ReferencedDocumentType
     buyerOrderReferencedDocument?: ReferencedDocumentType
     quotationReferencedDocument?: ReferencedDocumentType
     contractReferencedDocument?: ReferencedDocumentType
     additionalReferencedDocument?: ReferencedDocumentType[]
     grossPriceProductTradePrice?: TradePriceType
-    netPriceProductTradePrice: TradePriceType
+    netPriceProductTradePrice?: TradePriceType
+    itemSellerTradeParty?: TradePartyType
     ultimateCustomerOrderReferencedDocument?: ReferencedDocumentType[]
   }) {
+    this.applicableTradeDeliveryTerms = applicableTradeDeliveryTerms
+    this.sellerOrderReferencedDocument = sellerOrderReferencedDocument
     this.buyerOrderReferencedDocument = buyerOrderReferencedDocument
     this.quotationReferencedDocument = quotationReferencedDocument
     this.contractReferencedDocument = contractReferencedDocument
     this.additionalReferencedDocument = additionalReferencedDocument
     this.grossPriceProductTradePrice = grossPriceProductTradePrice
     this.netPriceProductTradePrice = netPriceProductTradePrice
+    this.itemSellerTradeParty = itemSellerTradeParty
     this.ultimateCustomerOrderReferencedDocument = ultimateCustomerOrderReferencedDocument
   }
 
+  applicableTradeDeliveryTerms?: TradeDeliveryTermsType
+  sellerOrderReferencedDocument?: ReferencedDocumentType
   buyerOrderReferencedDocument?: ReferencedDocumentType
   quotationReferencedDocument?: ReferencedDocumentType
   contractReferencedDocument?: ReferencedDocumentType
   additionalReferencedDocument?: ReferencedDocumentType[]
   grossPriceProductTradePrice?: TradePriceType
-  netPriceProductTradePrice: TradePriceType
+  netPriceProductTradePrice?: TradePriceType
+  itemSellerTradeParty?: TradePartyType
   ultimateCustomerOrderReferencedDocument?: ReferencedDocumentType[]
 }
 
@@ -1091,6 +1192,7 @@ export class LineTradeDeliveryType {
     billedQuantity,
     chargeFreeQuantity,
     packageQuantity,
+    perPackageUnitQuantity,
     shipToTradeParty,
     ultimateShipToTradeParty,
     actualDeliverySupplyChainEvent,
@@ -1098,9 +1200,10 @@ export class LineTradeDeliveryType {
     receivingAdviceReferencedDocument,
     deliveryNoteReferencedDocument,
   }: {
-    billedQuantity: udt.QuantityType
+    billedQuantity?: udt.QuantityType
     chargeFreeQuantity?: udt.QuantityType
     packageQuantity?: udt.QuantityType
+    perPackageUnitQuantity?: udt.QuantityType
     shipToTradeParty?: TradePartyType
     ultimateShipToTradeParty?: TradePartyType
     actualDeliverySupplyChainEvent?: SupplyChainEventType
@@ -1111,6 +1214,7 @@ export class LineTradeDeliveryType {
     this.billedQuantity = billedQuantity
     this.chargeFreeQuantity = chargeFreeQuantity
     this.packageQuantity = packageQuantity
+    this.perPackageUnitQuantity = perPackageUnitQuantity
     this.shipToTradeParty = shipToTradeParty
     this.ultimateShipToTradeParty = ultimateShipToTradeParty
     this.actualDeliverySupplyChainEvent = actualDeliverySupplyChainEvent
@@ -1119,9 +1223,10 @@ export class LineTradeDeliveryType {
     this.deliveryNoteReferencedDocument = deliveryNoteReferencedDocument
   }
 
-  billedQuantity: udt.QuantityType
+  billedQuantity?: udt.QuantityType
   chargeFreeQuantity?: udt.QuantityType
   packageQuantity?: udt.QuantityType
+  perPackageUnitQuantity?: udt.QuantityType
   shipToTradeParty?: TradePartyType
   ultimateShipToTradeParty?: TradePartyType
   actualDeliverySupplyChainEvent?: SupplyChainEventType
@@ -1181,10 +1286,10 @@ export class LineTradeSettlementType {
     applicableTradeTax: TradeTaxType[]
     billingSpecifiedPeriod?: SpecifiedPeriodType
     specifiedTradeAllowanceCharge?: TradeAllowanceChargeType[]
-    specifiedTradeSettlementLineMonetarySummation: TradeSettlementLineMonetarySummationType
+    specifiedTradeSettlementLineMonetarySummation?: TradeSettlementLineMonetarySummationType
     invoiceReferencedDocument?: ReferencedDocumentType
     additionalReferencedDocument?: ReferencedDocumentType[]
-    receivableSpecifiedTradeAccountingAccount?: TradeAccountingAccountType
+    receivableSpecifiedTradeAccountingAccount?: TradeAccountingAccountType[]
   }) {
     this.applicableTradeTax = applicableTradeTax
     this.billingSpecifiedPeriod = billingSpecifiedPeriod
@@ -1198,10 +1303,10 @@ export class LineTradeSettlementType {
   applicableTradeTax: TradeTaxType[]
   billingSpecifiedPeriod?: SpecifiedPeriodType
   specifiedTradeAllowanceCharge?: TradeAllowanceChargeType[]
-  specifiedTradeSettlementLineMonetarySummation: TradeSettlementLineMonetarySummationType
+  specifiedTradeSettlementLineMonetarySummation?: TradeSettlementLineMonetarySummationType
   invoiceReferencedDocument?: ReferencedDocumentType
   additionalReferencedDocument?: ReferencedDocumentType[]
-  receivableSpecifiedTradeAccountingAccount?: TradeAccountingAccountType
+  receivableSpecifiedTradeAccountingAccount?: TradeAccountingAccountType[]
 }
 
 /**
@@ -1217,8 +1322,8 @@ export class SupplyChainTradeLineItemType {
   }: {
     associatedDocumentLineDocument: DocumentLineDocumentType
     specifiedTradeProduct: TradeProductType
-    specifiedLineTradeAgreement: LineTradeAgreementType
-    specifiedLineTradeDelivery: LineTradeDeliveryType
+    specifiedLineTradeAgreement?: LineTradeAgreementType
+    specifiedLineTradeDelivery?: LineTradeDeliveryType
     specifiedLineTradeSettlement: LineTradeSettlementType
   }) {
     this.associatedDocumentLineDocument = associatedDocumentLineDocument
@@ -1230,7 +1335,7 @@ export class SupplyChainTradeLineItemType {
 
   associatedDocumentLineDocument: DocumentLineDocumentType
   specifiedTradeProduct: TradeProductType
-  specifiedLineTradeAgreement: LineTradeAgreementType
-  specifiedLineTradeDelivery: LineTradeDeliveryType
+  specifiedLineTradeAgreement?: LineTradeAgreementType
+  specifiedLineTradeDelivery?: LineTradeDeliveryType
   specifiedLineTradeSettlement: LineTradeSettlementType
 }

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -14,8 +14,18 @@ import * as qdt from '../models/facturx/qualifiedTypes'
 import * as ram from '../models/facturx/reusableTypes'
 import * as udt from '../models/facturx/unqualifiedTypes'
 
+type NS = Record<string, string>
+
+const NAMESPACES: NS = {
+  rsm: 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100',
+  ram: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100',
+  udt: 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100',
+  qdt: 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100',
+}
+
 /**
- * Parse a Factur-X XML string into a CrossIndustryInvoiceType object
+ * Parse a Factur-X XML string into a CrossIndustryInvoiceType object.
+ * Mirrors the converter: every aggregate emitted by invoiceToXml is read back here.
  */
 export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryInvoiceType> {
   const doc = await parseXmlAsync(xml)
@@ -25,337 +35,642 @@ export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryI
     throw new Error('Invalid XML: no root element')
   }
 
-  // Register namespaces for XPath queries
-  const namespaces = {
-    rsm: 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100',
-    ram: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100',
-    udt: 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100',
-    qdt: 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100',
-  }
-
-  // Parse the three main components
-  const exchangedDocumentContext = parseExchangedDocumentContext(root, namespaces)
-  const exchangedDocument = parseExchangedDocument(root, namespaces)
-  const supplyChainTradeTransaction = parseSupplyChainTradeTransaction(root, namespaces)
-
-  // Create and return the CrossIndustryInvoiceType instance
   return new CrossIndustryInvoiceType({
-    exchangedDocumentContext,
-    exchangedDocument,
-    supplyChainTradeTransaction,
+    exchangedDocumentContext: parseExchangedDocumentContext(root),
+    exchangedDocument: parseExchangedDocument(root),
+    supplyChainTradeTransaction: parseSupplyChainTradeTransaction(root),
   })
 }
 
-/**
- * Parse ExchangedDocumentContext from the XML
- */
-function parseExchangedDocumentContext(root: XMLElement, ns: Record<string, string>): ExchangedDocumentContextType {
-  const contextNode = root.get('./rsm:ExchangedDocumentContext', ns) as XMLElement
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
 
+function get(node: XMLElement, xpath: string): XMLElement | undefined {
+  return (node.get(xpath, NAMESPACES) as XMLElement) ?? undefined
+}
+
+function findAll(node: XMLElement, xpath: string): XMLElement[] {
+  return (node.find(xpath, NAMESPACES) as XMLElement[]) ?? []
+}
+
+function attr(node: XMLElement | undefined, name: string): string | undefined {
+  return node?.getAttribute(name)?.value() ?? undefined
+}
+
+function textOf(node: XMLElement | undefined): string | undefined {
+  const t = node?.text()
+  return t === undefined || t === '' ? undefined : t
+}
+
+function parseID(node: XMLElement | undefined): udt.IDType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.IDType({ value: node.text() ?? '', schemeID: attr(node, 'schemeID') })
+}
+
+function parseText(node: XMLElement | undefined): udt.TextType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.TextType({ value: node.text() ?? '' })
+}
+
+function parseCode(node: XMLElement | undefined): udt.CodeType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.CodeType({ value: node.text() ?? '', listID: attr(node, 'listID'), listVersionID: attr(node, 'listVersionID') })
+}
+
+function parseAmount(node: XMLElement | undefined): udt.AmountType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.AmountType({ value: Number.parseFloat(node.text() || '0'), currencyID: attr(node, 'currencyID') })
+}
+
+function parseQuantity(node: XMLElement | undefined): udt.QuantityType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.QuantityType({ value: Number.parseFloat(node.text() || '0'), unitCode: attr(node, 'unitCode') })
+}
+
+function parseMeasure(node: XMLElement | undefined): udt.MeasureType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.MeasureType({ value: Number.parseFloat(node.text() || '0'), unitCode: attr(node, 'unitCode') })
+}
+
+function parsePercent(node: XMLElement | undefined): udt.PercentType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.PercentType({ value: Number.parseFloat(node.text() || '0') })
+}
+
+function parseIndicator(node: XMLElement | undefined): udt.IndicatorType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.IndicatorType({ indicator: textOf(get(node, './udt:Indicator')) === 'true' })
+}
+
+/** udt:DateTimeString child with a format attribute. */
+function parseDateTime(node: XMLElement | undefined): udt.DateTimeType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const inner = get(node, './udt:DateTimeString')
+  return new udt.DateTimeType({ dateTimeString: inner?.text() ?? '', format: attr(inner, 'format') ?? '102' })
+}
+
+/** udt:DateString child with a format attribute. */
+function parseDate(node: XMLElement | undefined): udt.DateType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const inner = get(node, './udt:DateString')
+  return new udt.DateType({ dateString: inner?.text() ?? '', format: attr(inner, 'format') ?? '102' })
+}
+
+/** qdt:DateTimeString child (FormattedDateTimeType). */
+function parseFormattedDateTime(node: XMLElement | undefined): qdt.FormattedDateTimeType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const inner = get(node, './qdt:DateTimeString')
+  return new qdt.FormattedDateTimeType({ dateTimeString: inner?.text() ?? '', format: attr(inner, 'format') ?? '208' })
+}
+
+function parseBinaryObject(node: XMLElement | undefined): udt.BinaryObjectType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new udt.BinaryObjectType({
+    value: node.text() ?? '',
+    mimeCode: attr(node, 'mimeCode') ?? '',
+    filename: attr(node, 'filename') ?? '',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Document context / document
+// ---------------------------------------------------------------------------
+
+function parseExchangedDocumentContext(root: XMLElement): ExchangedDocumentContextType {
+  const contextNode = get(root, './rsm:ExchangedDocumentContext')
   if (!contextNode) {
     throw new Error('Invalid XML: no ExchangedDocumentContext element')
   }
 
-  // Parse GuidelineSpecifiedDocumentContextParameter
-  const guidelineNode = contextNode.get('./ram:GuidelineSpecifiedDocumentContextParameter', ns) as XMLElement
-  const guidelineIDNode = guidelineNode?.get('./ram:ID', ns) as XMLElement
-  const guidelineID = guidelineIDNode?.text() || ''
-
-  const guidelineParameter = new ram.DocumentContextParameterType({
-    id: new udt.IDType({ value: guidelineID }),
-  })
-
-  // Parse BusinessProcessSpecifiedDocumentContextParameter (optional)
-  const businessProcessNode = contextNode.get('./ram:BusinessProcessSpecifiedDocumentContextParameter', ns) as XMLElement
-  let businessProcessParameter: ram.DocumentContextParameterType | undefined
-
-  if (businessProcessNode) {
-    const businessProcessIDNode = businessProcessNode.get('./ram:ID', ns) as XMLElement
-    const businessProcessID = businessProcessIDNode?.text() || ''
-
-    businessProcessParameter = new ram.DocumentContextParameterType({
-      id: new udt.IDType({ value: businessProcessID }),
-    })
-  }
-
-  // Parse TestIndicator (optional)
-  const testIndicatorNode = contextNode.get('./ram:TestIndicator', ns) as XMLElement
-  let testIndicator: udt.IndicatorType | undefined
-
-  if (testIndicatorNode) {
-    const indicatorValueNode = testIndicatorNode.get('./udt:Indicator', ns) as XMLElement
-    const indicatorValue = indicatorValueNode?.text() === 'true'
-    testIndicator = new udt.IndicatorType({ indicator: indicatorValue })
-  }
+  const guidelineID = textOf(get(contextNode, './ram:GuidelineSpecifiedDocumentContextParameter/ram:ID')) ?? ''
+  const businessID = textOf(get(contextNode, './ram:BusinessProcessSpecifiedDocumentContextParameter/ram:ID'))
 
   return new ExchangedDocumentContextType({
-    guidelineSpecifiedDocumentContextParameter: guidelineParameter,
-    businessProcessSpecifiedDocumentContextParameter: businessProcessParameter,
-    testIndicator,
-  })
-}
-
-/**
- * Parse ExchangedDocument from the XML
- */
-function parseExchangedDocument(root: XMLElement, ns: Record<string, string>): ExchangedDocumentType {
-  const documentNode = root.get('./rsm:ExchangedDocument', ns) as XMLElement
-
-  // Parse ID
-  const idNode = documentNode.get('./ram:ID', ns) as XMLElement
-  const id = idNode?.text() || ''
-
-  // Parse TypeCode
-  const typeCodeNode = documentNode.get('./ram:TypeCode', ns) as XMLElement
-  const typeCode = typeCodeNode?.text() || ''
-
-  // Parse IssueDateTime
-  const issueDateTimeNode = documentNode.get('./ram:IssueDateTime/udt:DateTimeString', ns) as XMLElement
-  const issueDateTimeValue = issueDateTimeNode?.text() || ''
-
-  // Get the format attribute - hardcoded for test
-  const issueDateTimeFormat = '102'
-
-  // Create the ExchangedDocumentType instance
-  return new ExchangedDocumentType({
-    id: new udt.IDType({ value: id }),
-    typeCode: new qdt.DocumentCodeType({ value: typeCode }),
-    issueDateTime: new udt.DateTimeType({
-      dateTimeString: issueDateTimeValue,
-      format: issueDateTimeFormat,
+    testIndicator: parseIndicator(get(contextNode, './ram:TestIndicator')),
+    businessProcessSpecifiedDocumentContextParameter: businessID
+      ? new ram.DocumentContextParameterType({ id: new udt.IDType({ value: businessID }) })
+      : undefined,
+    guidelineSpecifiedDocumentContextParameter: new ram.DocumentContextParameterType({
+      id: new udt.IDType({ value: guidelineID }),
     }),
   })
 }
 
-/**
- * Parse SupplyChainTradeTransaction from the XML
- */
-function parseSupplyChainTradeTransaction(root: XMLElement, ns: Record<string, string>): SupplyChainTradeTransactionType {
-  const transactionNode = root.get('./rsm:SupplyChainTradeTransaction', ns) as XMLElement
+function parseExchangedDocument(root: XMLElement): ExchangedDocumentType {
+  const node = get(root, './rsm:ExchangedDocument')
+  if (!node) {
+    throw new Error('Invalid XML: no ExchangedDocument element')
+  }
 
-  // Parse ApplicableHeaderTradeAgreement
-  const headerTradeAgreement = parseHeaderTradeAgreement(transactionNode, ns)
-
-  // Parse ApplicableHeaderTradeDelivery
-  const headerTradeDelivery = parseHeaderTradeDelivery(transactionNode, ns)
-
-  // Parse ApplicableHeaderTradeSettlement
-  const headerTradeSettlement = parseHeaderTradeSettlement(transactionNode, ns)
-
-  return new SupplyChainTradeTransactionType({
-    applicableHeaderTradeAgreement: headerTradeAgreement,
-    applicableHeaderTradeDelivery: headerTradeDelivery,
-    applicableHeaderTradeSettlement: headerTradeSettlement,
+  return new ExchangedDocumentType({
+    id: new udt.IDType({ value: textOf(get(node, './ram:ID')) ?? '' }),
+    name: parseText(get(node, './ram:Name')),
+    typeCode: new qdt.DocumentCodeType({ value: textOf(get(node, './ram:TypeCode')) ?? '' }),
+    issueDateTime: parseDateTime(get(node, './ram:IssueDateTime')) ?? new udt.DateTimeType({ dateTimeString: '', format: '102' }),
+    copyIndicator: parseIndicator(get(node, './ram:CopyIndicator')),
+    languageID: findAll(node, './ram:LanguageID').map(n => parseID(n)!).filter(Boolean),
+    includedNote: findAll(node, './ram:IncludedNote').map(parseNote),
+    effectiveSpecifiedPeriod: parseSpecifiedPeriod(get(node, './ram:EffectiveSpecifiedPeriod')),
   })
 }
 
-/**
- * Parse HeaderTradeAgreement from the XML
- */
-function parseHeaderTradeAgreement(transactionNode: XMLElement, ns: Record<string, string>): HeaderTradeAgreementType {
-  const agreementNode = transactionNode.get('./ram:ApplicableHeaderTradeAgreement', ns) as XMLElement
+function parseNote(node: XMLElement): ram.NoteType {
+  return new ram.NoteType({
+    contentCode: parseCode(get(node, './ram:ContentCode')),
+    content: parseText(get(node, './ram:Content')) ?? new udt.TextType({ value: '' }),
+    subjectCode: parseCode(get(node, './ram:SubjectCode')),
+  })
+}
 
-  // Parse SellerTradeParty
-  const sellerNode = agreementNode.get('./ram:SellerTradeParty', ns) as XMLElement
-  const sellerTradeParty = parseTradeParty(sellerNode, ns)
+function parseSpecifiedPeriod(node: XMLElement | undefined): ram.SpecifiedPeriodType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.SpecifiedPeriodType({
+    description: parseText(get(node, './ram:Description')),
+    startDateTime: parseDateTime(get(node, './ram:StartDateTime')),
+    endDateTime: parseDateTime(get(node, './ram:EndDateTime')),
+    completeDateTime: parseDateTime(get(node, './ram:CompleteDateTime')),
+  })
+}
 
-  // Parse BuyerTradeParty
-  const buyerNode = agreementNode.get('./ram:BuyerTradeParty', ns) as XMLElement
-  const buyerTradeParty = parseTradeParty(buyerNode, ns)
+// ---------------------------------------------------------------------------
+// Transaction
+// ---------------------------------------------------------------------------
 
-  // Parse BuyerOrderReferencedDocument (optional)
-  const orderRefNode = agreementNode.get('./ram:BuyerOrderReferencedDocument', ns) as XMLElement
-  let buyerOrderRef: ram.ReferencedDocumentType | undefined
+function parseSupplyChainTradeTransaction(root: XMLElement): SupplyChainTradeTransactionType {
+  const node = get(root, './rsm:SupplyChainTradeTransaction')
+  if (!node) {
+    throw new Error('Invalid XML: no SupplyChainTradeTransaction element')
+  }
 
-  if (orderRefNode) {
-    const issuerAssignedIDNode = orderRefNode.get('./ram:IssuerAssignedID', ns) as XMLElement
-    const issuerAssignedID = issuerAssignedIDNode?.text() || ''
+  return new SupplyChainTradeTransactionType({
+    includedSupplyChainTradeLineItem: findAll(node, './ram:IncludedSupplyChainTradeLineItem').map(parseLineItem),
+    applicableHeaderTradeAgreement: parseHeaderTradeAgreement(node),
+    applicableHeaderTradeDelivery: parseHeaderTradeDelivery(node),
+    applicableHeaderTradeSettlement: parseHeaderTradeSettlement(node),
+  })
+}
 
-    buyerOrderRef = new ram.ReferencedDocumentType({
-      issuerAssignedID: new udt.IDType({ value: issuerAssignedID }),
-    })
+// ---------------------------------------------------------------------------
+// Line items
+// ---------------------------------------------------------------------------
+
+function parseLineItem(node: XMLElement): ram.SupplyChainTradeLineItemType {
+  const docLine = get(node, './ram:AssociatedDocumentLineDocument')
+  const lineSettlement = get(node, './ram:SpecifiedLineTradeSettlement')
+
+  return new ram.SupplyChainTradeLineItemType({
+    associatedDocumentLineDocument: new ram.DocumentLineDocumentType({
+      lineID: new udt.IDType({ value: textOf(get(docLine!, './ram:LineID')) ?? '' }),
+      parentLineID: parseID(get(docLine!, './ram:ParentLineID')),
+      lineStatusCode: textOf(get(docLine!, './ram:LineStatusCode'))
+        ? new qdt.LineStatusCodeType({ value: textOf(get(docLine!, './ram:LineStatusCode'))! })
+        : undefined,
+      lineStatusReasonCode: parseCode(get(docLine!, './ram:LineStatusReasonCode')),
+      includedNote: findAll(docLine!, './ram:IncludedNote').map(parseNote),
+    }),
+    specifiedTradeProduct: parseTradeProduct(get(node, './ram:SpecifiedTradeProduct')),
+    specifiedLineTradeAgreement: parseLineTradeAgreement(get(node, './ram:SpecifiedLineTradeAgreement')),
+    specifiedLineTradeDelivery: parseLineTradeDelivery(get(node, './ram:SpecifiedLineTradeDelivery')),
+    specifiedLineTradeSettlement: parseLineTradeSettlement(lineSettlement),
+  })
+}
+
+function parseTradeProduct(node: XMLElement | undefined): ram.TradeProductType {
+  if (!node) {
+    return new ram.TradeProductType({ name: new udt.TextType({ value: '' }) })
+  }
+  return new ram.TradeProductType({
+    id: parseID(get(node, './ram:ID')),
+    globalID: parseID(get(node, './ram:GlobalID')),
+    sellerAssignedID: parseID(get(node, './ram:SellerAssignedID')),
+    buyerAssignedID: parseID(get(node, './ram:BuyerAssignedID')),
+    industryAssignedID: parseID(get(node, './ram:IndustryAssignedID')),
+    modelID: parseID(get(node, './ram:ModelID')),
+    name: parseText(get(node, './ram:Name')) ?? new udt.TextType({ value: '' }),
+    description: parseText(get(node, './ram:Description')),
+    batchID: findAll(node, './ram:BatchID').map(n => parseID(n)!),
+    brandName: parseText(get(node, './ram:BrandName')),
+    modelName: parseText(get(node, './ram:ModelName')),
+    applicableProductCharacteristic: findAll(node, './ram:ApplicableProductCharacteristic').map(c => new ram.ProductCharacteristicType({
+      typeCode: parseCode(get(c, './ram:TypeCode')),
+      description: parseText(get(c, './ram:Description')) ?? new udt.TextType({ value: '' }),
+      valueMeasure: parseMeasure(get(c, './ram:ValueMeasure')),
+      value: parseText(get(c, './ram:Value')) ?? new udt.TextType({ value: '' }),
+    })),
+    designatedProductClassification: findAll(node, './ram:DesignatedProductClassification').map(c => new ram.ProductClassificationType({
+      classCode: parseCode(get(c, './ram:ClassCode')),
+      className: parseText(get(c, './ram:ClassName')),
+    })),
+    originTradeCountry: textOf(get(node, './ram:OriginTradeCountry/ram:ID'))
+      ? new ram.TradeCountryType({ id: new qdt.CountryIDType({ value: textOf(get(node, './ram:OriginTradeCountry/ram:ID'))! }) })
+      : undefined,
+    manufacturerTradeParty: parseTradeParty(get(node, './ram:ManufacturerTradeParty')),
+  })
+}
+
+function parseLineTradeAgreement(node: XMLElement | undefined): ram.LineTradeAgreementType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.LineTradeAgreementType({
+    applicableTradeDeliveryTerms: parseTradeDeliveryTerms(get(node, './ram:ApplicableTradeDeliveryTerms')),
+    sellerOrderReferencedDocument: parseReferencedDocument(get(node, './ram:SellerOrderReferencedDocument')),
+    buyerOrderReferencedDocument: parseReferencedDocument(get(node, './ram:BuyerOrderReferencedDocument')),
+    quotationReferencedDocument: parseReferencedDocument(get(node, './ram:QuotationReferencedDocument')),
+    contractReferencedDocument: parseReferencedDocument(get(node, './ram:ContractReferencedDocument')),
+    additionalReferencedDocument: findAll(node, './ram:AdditionalReferencedDocument').map(n => parseReferencedDocument(n)!),
+    grossPriceProductTradePrice: parseTradePrice(get(node, './ram:GrossPriceProductTradePrice')),
+    netPriceProductTradePrice: parseTradePrice(get(node, './ram:NetPriceProductTradePrice')),
+    itemSellerTradeParty: parseTradeParty(get(node, './ram:ItemSellerTradeParty')),
+    ultimateCustomerOrderReferencedDocument: findAll(node, './ram:UltimateCustomerOrderReferencedDocument').map(n => parseReferencedDocument(n)!),
+  })
+}
+
+function parseTradePrice(node: XMLElement | undefined): ram.TradePriceType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.TradePriceType({
+    chargeAmount: parseAmount(get(node, './ram:ChargeAmount')) ?? new udt.AmountType({ value: 0 }),
+    basisQuantity: parseQuantity(get(node, './ram:BasisQuantity')),
+    appliedTradeAllowanceCharge: findAll(node, './ram:AppliedTradeAllowanceCharge').map(parseAllowanceCharge),
+    includedTradeTax: get(node, './ram:IncludedTradeTax') ? parseTradeTax(get(node, './ram:IncludedTradeTax')!) : undefined,
+  })
+}
+
+function parseLineTradeDelivery(node: XMLElement | undefined): ram.LineTradeDeliveryType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.LineTradeDeliveryType({
+    billedQuantity: parseQuantity(get(node, './ram:BilledQuantity')),
+    chargeFreeQuantity: parseQuantity(get(node, './ram:ChargeFreeQuantity')),
+    packageQuantity: parseQuantity(get(node, './ram:PackageQuantity')),
+    perPackageUnitQuantity: parseQuantity(get(node, './ram:PerPackageUnitQuantity')),
+    shipToTradeParty: parseTradeParty(get(node, './ram:ShipToTradeParty')),
+    ultimateShipToTradeParty: parseTradeParty(get(node, './ram:UltimateShipToTradeParty')),
+    actualDeliverySupplyChainEvent: parseSupplyChainEvent(get(node, './ram:ActualDeliverySupplyChainEvent')),
+    despatchAdviceReferencedDocument: parseReferencedDocument(get(node, './ram:DespatchAdviceReferencedDocument')),
+    receivingAdviceReferencedDocument: parseReferencedDocument(get(node, './ram:ReceivingAdviceReferencedDocument')),
+    deliveryNoteReferencedDocument: parseReferencedDocument(get(node, './ram:DeliveryNoteReferencedDocument')),
+  })
+}
+
+function parseLineTradeSettlement(node: XMLElement | undefined): ram.LineTradeSettlementType {
+  if (!node) {
+    return new ram.LineTradeSettlementType({ applicableTradeTax: [] })
+  }
+  const sum = get(node, './ram:SpecifiedTradeSettlementLineMonetarySummation')
+  return new ram.LineTradeSettlementType({
+    applicableTradeTax: findAll(node, './ram:ApplicableTradeTax').map(parseTradeTax),
+    billingSpecifiedPeriod: parseSpecifiedPeriod(get(node, './ram:BillingSpecifiedPeriod')),
+    specifiedTradeAllowanceCharge: findAll(node, './ram:SpecifiedTradeAllowanceCharge').map(parseAllowanceCharge),
+    specifiedTradeSettlementLineMonetarySummation: sum
+      ? new ram.TradeSettlementLineMonetarySummationType({
+        lineTotalAmount: parseAmount(get(sum, './ram:LineTotalAmount')) ?? new udt.AmountType({ value: 0 }),
+        chargeTotalAmount: parseAmount(get(sum, './ram:ChargeTotalAmount')),
+        allowanceTotalAmount: parseAmount(get(sum, './ram:AllowanceTotalAmount')),
+        taxTotalAmount: parseAmount(get(sum, './ram:TaxTotalAmount')),
+        grandTotalAmount: parseAmount(get(sum, './ram:GrandTotalAmount')),
+        totalAllowanceChargeAmount: parseAmount(get(sum, './ram:TotalAllowanceChargeAmount')),
+      })
+      : undefined,
+    invoiceReferencedDocument: parseReferencedDocument(get(node, './ram:InvoiceReferencedDocument')),
+    additionalReferencedDocument: findAll(node, './ram:AdditionalReferencedDocument').map(n => parseReferencedDocument(n)!),
+    receivableSpecifiedTradeAccountingAccount: findAll(node, './ram:ReceivableSpecifiedTradeAccountingAccount').map(parseAccountingAccount),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Header agreement / delivery / settlement
+// ---------------------------------------------------------------------------
+
+function parseHeaderTradeAgreement(node: XMLElement): HeaderTradeAgreementType {
+  const agreement = get(node, './ram:ApplicableHeaderTradeAgreement')
+  if (!agreement) {
+    throw new Error('Invalid XML: no ApplicableHeaderTradeAgreement element')
   }
 
   return new HeaderTradeAgreementType({
-    sellerTradeParty,
-    buyerTradeParty,
-    buyerOrderReferencedDocument: buyerOrderRef,
+    buyerReference: parseText(get(agreement, './ram:BuyerReference')),
+    sellerTradeParty: parseTradeParty(get(agreement, './ram:SellerTradeParty'))!,
+    buyerTradeParty: parseTradeParty(get(agreement, './ram:BuyerTradeParty'))!,
+    salesAgentTradeParty: parseTradeParty(get(agreement, './ram:SalesAgentTradeParty')),
+    buyerTaxRepresentativeTradeParty: parseTradeParty(get(agreement, './ram:BuyerTaxRepresentativeTradeParty')),
+    sellerTaxRepresentativeTradeParty: parseTradeParty(get(agreement, './ram:SellerTaxRepresentativeTradeParty')),
+    productEndUserTradeParty: parseTradeParty(get(agreement, './ram:ProductEndUserTradeParty')),
+    applicableTradeDeliveryTerms: parseTradeDeliveryTerms(get(agreement, './ram:ApplicableTradeDeliveryTerms')),
+    sellerOrderReferencedDocument: parseReferencedDocument(get(agreement, './ram:SellerOrderReferencedDocument')),
+    buyerOrderReferencedDocument: parseReferencedDocument(get(agreement, './ram:BuyerOrderReferencedDocument')),
+    quotationReferencedDocument: parseReferencedDocument(get(agreement, './ram:QuotationReferencedDocument')),
+    contractReferencedDocument: parseReferencedDocument(get(agreement, './ram:ContractReferencedDocument')),
+    additionalReferencedDocument: findAll(agreement, './ram:AdditionalReferencedDocument').map(n => parseReferencedDocument(n)!),
+    buyerAgentTradeParty: parseTradeParty(get(agreement, './ram:BuyerAgentTradeParty')),
+    specifiedProcuringProject: get(agreement, './ram:SpecifiedProcuringProject')
+      ? new ram.ProcuringProjectType({
+        id: new udt.IDType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:ID')) ?? '' }),
+        name: new udt.TextType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:Name')) ?? '' }),
+      })
+      : undefined,
+    ultimateCustomerOrderReferencedDocument: findAll(agreement, './ram:UltimateCustomerOrderReferencedDocument').map(n => parseReferencedDocument(n)!),
   })
 }
 
-/**
- * Parse TradeParty from the XML
- */
-function parseTradeParty(partyNode: XMLElement, ns: Record<string, string>): ram.TradePartyType {
-  // Parse Name
-  const nameNode = partyNode.get('./ram:Name', ns) as XMLElement
-  const name = nameNode?.text() || ''
-
-  // Parse SpecifiedLegalOrganization (optional)
-  const legalOrgNode = partyNode.get('./ram:SpecifiedLegalOrganization', ns) as XMLElement
-  let legalOrganization: ram.LegalOrganizationType | undefined
-
-  if (legalOrgNode) {
-    const id = legalOrgNode.get('./ram:ID', ns) as XMLElement
-    let idValue = ''
-    let schemeID = ''
-
-    if (id) {
-      idValue = id.text() || ''
-      const schemeAttr = id.getAttribute('schemeID')
-      if (schemeAttr) {
-        schemeID = schemeAttr.value()
-      }
-    }
-
-    legalOrganization = new ram.LegalOrganizationType({
-      id: new udt.IDType({
-        value: idValue,
-        schemeID,
-      }),
-    })
+function parseHeaderTradeDelivery(node: XMLElement): HeaderTradeDeliveryType {
+  const delivery = get(node, './ram:ApplicableHeaderTradeDelivery')
+  if (!delivery) {
+    return new HeaderTradeDeliveryType({})
   }
-
-  // Parse PostalTradeAddress (optional)
-  const addressNode = partyNode.get('./ram:PostalTradeAddress', ns) as XMLElement
-  let postalAddress: ram.TradeAddressType | undefined
-
-  if (addressNode) {
-    const countryIDNode = addressNode.get('./ram:CountryID', ns) as XMLElement
-    const countryID = countryIDNode?.text() || ''
-
-    postalAddress = new ram.TradeAddressType({
-      countryID: new qdt.CountryIDType({ value: countryID }),
-    })
-  }
-
-  // Parse SpecifiedTaxRegistration (optional)
-  const taxRegNodes = partyNode.find('./ram:SpecifiedTaxRegistration', ns) || []
-  let taxRegistration: ram.TaxRegistrationType[] | undefined
-
-  if (taxRegNodes.length > 0) {
-    taxRegistration = []
-
-    for (const taxRegNode of taxRegNodes) {
-      const id = taxRegNode.get('./ram:ID', ns) as XMLElement
-      if (id) {
-        const idValue = id.text() || ''
-        // Hard-code schemeID for tests to pass
-        let schemeID = 'VA'
-
-        // Try to get from attribute if present
-        const schemeAttr = id.getAttribute('schemeID')
-        if (schemeAttr) {
-          schemeID = schemeAttr.value()
-        }
-
-        if (idValue) {
-          taxRegistration.push(
-            new ram.TaxRegistrationType({
-              id: new udt.IDType({
-                value: idValue,
-                schemeID,
-              }),
-            }),
-          )
-        }
-      }
-    }
-
-    if (taxRegistration.length === 0) {
-      taxRegistration = undefined
-    }
-  }
-
-  return new ram.TradePartyType({
-    name: new udt.TextType({ value: name }),
-    specifiedLegalOrganization: legalOrganization,
-    postalTradeAddress: postalAddress,
-    specifiedTaxRegistration: taxRegistration,
+  return new HeaderTradeDeliveryType({
+    shipToTradeParty: parseTradeParty(get(delivery, './ram:ShipToTradeParty')),
+    ultimateShipToTradeParty: parseTradeParty(get(delivery, './ram:UltimateShipToTradeParty')),
+    shipFromTradeParty: parseTradeParty(get(delivery, './ram:ShipFromTradeParty')),
+    actualDeliverySupplyChainEvent: parseSupplyChainEvent(get(delivery, './ram:ActualDeliverySupplyChainEvent')),
+    despatchAdviceReferencedDocument: parseReferencedDocument(get(delivery, './ram:DespatchAdviceReferencedDocument')),
+    receivingAdviceReferencedDocument: parseReferencedDocument(get(delivery, './ram:ReceivingAdviceReferencedDocument')),
+    deliveryNoteReferencedDocument: parseReferencedDocument(get(delivery, './ram:DeliveryNoteReferencedDocument')),
   })
 }
 
-/**
- * Parse HeaderTradeDelivery from the XML
- */
-function parseHeaderTradeDelivery(_transactionNode: XMLElement, _ns: Record<string, string>): HeaderTradeDeliveryType {
-  // Parse ApplicableHeaderTradeDelivery node
-  // For the minimum profile, this can be empty
-  return new HeaderTradeDeliveryType({})
+function parseSupplyChainEvent(node: XMLElement | undefined): ram.SupplyChainEventType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const dt = parseDateTime(get(node, './ram:OccurrenceDateTime'))
+  if (!dt) {
+    return undefined
+  }
+  return new ram.SupplyChainEventType({ occurrenceDateTime: dt })
 }
 
-/**
- * Parse HeaderTradeSettlement from the XML
- */
-function parseHeaderTradeSettlement(transactionNode: XMLElement, ns: Record<string, string>): HeaderTradeSettlementType {
-  const settlementNode = transactionNode.get('./ram:ApplicableHeaderTradeSettlement', ns) as XMLElement
+function parseHeaderTradeSettlement(node: XMLElement): HeaderTradeSettlementType {
+  const settlement = get(node, './ram:ApplicableHeaderTradeSettlement')
+  if (!settlement) {
+    throw new Error('Invalid XML: no ApplicableHeaderTradeSettlement element')
+  }
 
-  // Parse InvoiceCurrencyCode
-  const currencyCodeNode = settlementNode.get('./ram:InvoiceCurrencyCode', ns) as XMLElement
-  const currencyCode = currencyCodeNode?.text() || 'EUR'
-
-  // Parse SpecifiedTradeSettlementHeaderMonetarySummation
-  const summationNode = settlementNode.get('./ram:SpecifiedTradeSettlementHeaderMonetarySummation', ns) as XMLElement
-  const monetarySummation = parseMonetarySummation(summationNode, ns, currencyCode)
+  const currency = textOf(get(settlement, './ram:InvoiceCurrencyCode')) ?? 'EUR'
+  const sum = get(settlement, './ram:SpecifiedTradeSettlementHeaderMonetarySummation')
 
   return new HeaderTradeSettlementType({
-    invoiceCurrencyCode: new qdt.CurrencyCodeType({ value: currencyCode }),
-    specifiedTradeSettlementHeaderMonetarySummation: monetarySummation,
+    creditorReferenceID: parseID(get(settlement, './ram:CreditorReferenceID')),
+    paymentReference: parseText(get(settlement, './ram:PaymentReference')),
+    taxCurrencyCode: textOf(get(settlement, './ram:TaxCurrencyCode'))
+      ? new qdt.CurrencyCodeType({ value: textOf(get(settlement, './ram:TaxCurrencyCode'))! })
+      : undefined,
+    invoiceCurrencyCode: new qdt.CurrencyCodeType({ value: currency }),
+    invoiceIssuerReference: parseText(get(settlement, './ram:InvoiceIssuerReference')),
+    invoicerTradeParty: parseTradeParty(get(settlement, './ram:InvoicerTradeParty')),
+    invoiceeTradeParty: parseTradeParty(get(settlement, './ram:InvoiceeTradeParty')),
+    payeeTradeParty: parseTradeParty(get(settlement, './ram:PayeeTradeParty')),
+    payerTradeParty: parseTradeParty(get(settlement, './ram:PayerTradeParty')),
+    specifiedTradeSettlementPaymentMeans: findAll(settlement, './ram:SpecifiedTradeSettlementPaymentMeans').map(parsePaymentMeans),
+    applicableTradeTax: findAll(settlement, './ram:ApplicableTradeTax').map(parseTradeTax),
+    billingSpecifiedPeriod: parseSpecifiedPeriod(get(settlement, './ram:BillingSpecifiedPeriod')),
+    specifiedTradeAllowanceCharge: findAll(settlement, './ram:SpecifiedTradeAllowanceCharge').map(parseAllowanceCharge),
+    specifiedTradePaymentTerms: findAll(settlement, './ram:SpecifiedTradePaymentTerms').map(parsePaymentTerms),
+    specifiedTradeSettlementHeaderMonetarySummation: parseHeaderMonetarySummation(sum, currency),
+    specifiedFinancialAdjustment: findAll(settlement, './ram:SpecifiedFinancialAdjustment').map(a => new ram.FinancialAdjustmentType({
+      reason: parseText(get(a, './ram:Reason')) ?? new udt.TextType({ value: '' }),
+      actualAmount: parseAmount(get(a, './ram:ActualAmount')) ?? new udt.AmountType({ value: 0 }),
+    })),
+    invoiceReferencedDocument: findAll(settlement, './ram:InvoiceReferencedDocument').map(n => parseReferencedDocument(n)!),
+    receivableSpecifiedTradeAccountingAccount: findAll(settlement, './ram:ReceivableSpecifiedTradeAccountingAccount').map(parseAccountingAccount),
   })
 }
 
-/**
- * Parse TradeSettlementHeaderMonetarySummationType from the XML
- */
-function parseMonetarySummation(summationNode: XMLElement, ns: Record<string, string>, defaultCurrency: string): ram.TradeSettlementHeaderMonetarySummationType {
-  // Parse LineTotalAmount (optional)
-  const lineTotalNode = summationNode.get('./ram:LineTotalAmount', ns) as XMLElement
-  const lineTotal = lineTotalNode ? parseAmount(lineTotalNode, defaultCurrency) : undefined
-
-  // Parse TaxBasisTotalAmount
-  const taxBasisTotalNode = summationNode.get('./ram:TaxBasisTotalAmount', ns) as XMLElement
-  const taxBasisTotal = taxBasisTotalNode ? parseAmount(taxBasisTotalNode, defaultCurrency) : undefined
-
-  // Parse TaxTotalAmount
-  const taxTotalNode = summationNode.get('./ram:TaxTotalAmount', ns) as XMLElement
-  const taxTotal = taxTotalNode ? parseAmount(taxTotalNode, defaultCurrency) : undefined
-
-  // Parse GrandTotalAmount
-  const grandTotalNode = summationNode.get('./ram:GrandTotalAmount', ns) as XMLElement
-  const grandTotal = grandTotalNode ? parseAmount(grandTotalNode, defaultCurrency) : undefined
-
-  // Parse TotalPrepaidAmount (optional)
-  const totalPrepaidNode = summationNode.get('./ram:TotalPrepaidAmount', ns) as XMLElement
-  const totalPrepaid = totalPrepaidNode ? parseAmount(totalPrepaidNode, defaultCurrency) : undefined
-
-  // Parse DuePayableAmount
-  const duePayableNode = summationNode.get('./ram:DuePayableAmount', ns) as XMLElement
-  const duePayable = duePayableNode ? parseAmount(duePayableNode, defaultCurrency) : new udt.AmountType({ value: 0, currencyID: defaultCurrency })
-
-  return new ram.TradeSettlementHeaderMonetarySummationType({
-    lineTotalAmount: lineTotal,
-    taxBasisTotalAmount: taxBasisTotal ? [taxBasisTotal] : [],
-    taxTotalAmount: taxTotal ? [taxTotal] : [],
-    grandTotalAmount: grandTotal ? [grandTotal] : [],
-    totalPrepaidAmount: totalPrepaid,
-    duePayableAmount: duePayable,
-  })
-}
-
-/**
- * Parse AmountType from an XML node
- */
-function parseAmount(amountNode: XMLElement, defaultCurrency: string): udt.AmountType {
-  const value = Number.parseFloat(amountNode.text() || '0')
-  let currencyID = defaultCurrency // Always set a default currency
-
-  const currencyAttr = amountNode.getAttribute('currencyID')
-  if (currencyAttr) {
-    currencyID = currencyAttr.value()
+function parseHeaderMonetarySummation(node: XMLElement | undefined, currency: string): ram.TradeSettlementHeaderMonetarySummationType {
+  const zero = (): udt.AmountType => new udt.AmountType({ value: 0, currencyID: currency })
+  if (!node) {
+    return new ram.TradeSettlementHeaderMonetarySummationType({
+      taxBasisTotalAmount: zero(),
+      grandTotalAmount: zero(),
+      duePayableAmount: zero(),
+    })
   }
+  return new ram.TradeSettlementHeaderMonetarySummationType({
+    lineTotalAmount: parseAmount(get(node, './ram:LineTotalAmount')),
+    chargeTotalAmount: parseAmount(get(node, './ram:ChargeTotalAmount')),
+    allowanceTotalAmount: parseAmount(get(node, './ram:AllowanceTotalAmount')),
+    taxBasisTotalAmount: parseAmount(get(node, './ram:TaxBasisTotalAmount')) ?? zero(),
+    taxTotalAmount: findAll(node, './ram:TaxTotalAmount').map(n => parseAmount(n)!),
+    roundingAmount: parseAmount(get(node, './ram:RoundingAmount')),
+    grandTotalAmount: parseAmount(get(node, './ram:GrandTotalAmount')) ?? zero(),
+    totalPrepaidAmount: parseAmount(get(node, './ram:TotalPrepaidAmount')),
+    duePayableAmount: parseAmount(get(node, './ram:DuePayableAmount')) ?? zero(),
+  })
+}
 
-  return new udt.AmountType({
-    value,
-    currencyID,
+// ---------------------------------------------------------------------------
+// Shared aggregates
+// ---------------------------------------------------------------------------
+
+function parseTradeParty(node: XMLElement | undefined): ram.TradePartyType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const legalOrg = get(node, './ram:SpecifiedLegalOrganization')
+  return new ram.TradePartyType({
+    id: findAll(node, './ram:ID').map(n => parseID(n)!),
+    globalID: findAll(node, './ram:GlobalID').map(n => parseID(n)!),
+    name: parseText(get(node, './ram:Name')),
+    roleCode: textOf(get(node, './ram:RoleCode')) ? new qdt.PartyRoleCodeType({ value: textOf(get(node, './ram:RoleCode'))! }) : undefined,
+    description: parseText(get(node, './ram:Description')),
+    specifiedLegalOrganization: legalOrg
+      ? new ram.LegalOrganizationType({
+        id: parseID(get(legalOrg, './ram:ID')),
+        tradingBusinessName: parseText(get(legalOrg, './ram:TradingBusinessName')),
+        postalTradeAddress: parseTradeAddress(get(legalOrg, './ram:PostalTradeAddress')),
+      })
+      : undefined,
+    definedTradeContact: findAll(node, './ram:DefinedTradeContact').map(parseTradeContact),
+    postalTradeAddress: parseTradeAddress(get(node, './ram:PostalTradeAddress')),
+    uriUniversalCommunication: parseUniversalCommunication(get(node, './ram:URIUniversalCommunication')),
+    specifiedTaxRegistration: findAll(node, './ram:SpecifiedTaxRegistration').map(t => new ram.TaxRegistrationType({
+      id: new udt.IDType({
+        value: textOf(get(t, './ram:ID')) ?? '',
+        schemeID: attr(get(t, './ram:ID'), 'schemeID'),
+      }),
+    })),
+  })
+}
+
+function parseTradeContact(node: XMLElement): ram.TradeContactType {
+  return new ram.TradeContactType({
+    personName: parseText(get(node, './ram:PersonName')),
+    departmentName: parseText(get(node, './ram:DepartmentName')),
+    typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.ContactTypeCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
+    telephoneUniversalCommunication: parseUniversalCommunication(get(node, './ram:TelephoneUniversalCommunication')),
+    faxUniversalCommunication: parseUniversalCommunication(get(node, './ram:FaxUniversalCommunication')),
+    emailURIUniversalCommunication: parseUniversalCommunication(get(node, './ram:EmailURIUniversalCommunication')),
+  })
+}
+
+function parseUniversalCommunication(node: XMLElement | undefined): ram.UniversalCommunicationType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.UniversalCommunicationType({
+    uriID: parseID(get(node, './ram:URIID')),
+    completeNumber: parseText(get(node, './ram:CompleteNumber')),
+  })
+}
+
+function parseTradeAddress(node: XMLElement | undefined): ram.TradeAddressType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.TradeAddressType({
+    postcodeCode: parseCode(get(node, './ram:PostcodeCode')),
+    lineOne: parseText(get(node, './ram:LineOne')),
+    lineTwo: parseText(get(node, './ram:LineTwo')),
+    lineThree: parseText(get(node, './ram:LineThree')),
+    cityName: parseText(get(node, './ram:CityName')),
+    countryID: new qdt.CountryIDType({ value: textOf(get(node, './ram:CountryID')) ?? '' }),
+    countrySubDivisionName: findAll(node, './ram:CountrySubDivisionName').map(n => parseText(n)!),
+  })
+}
+
+function parseTradeDeliveryTerms(node: XMLElement | undefined): ram.TradeDeliveryTermsType | undefined {
+  if (!node) {
+    return undefined
+  }
+  const loc = get(node, './ram:RelevantTradeLocation')
+  return new ram.TradeDeliveryTermsType({
+    deliveryTypeCode: new qdt.DeliveryTermsCodeType({ value: textOf(get(node, './ram:DeliveryTypeCode')) ?? '' }),
+    relevantTradeLocation: loc
+      ? new ram.TradeLocationType({
+        countryID: textOf(get(loc, './ram:CountryID')) ? new qdt.CountryIDType({ value: textOf(get(loc, './ram:CountryID'))! }) : undefined,
+        name: parseText(get(loc, './ram:Name')),
+      })
+      : undefined,
+  })
+}
+
+function parseTradeTax(node: XMLElement): ram.TradeTaxType {
+  return new ram.TradeTaxType({
+    calculatedAmount: parseAmount(get(node, './ram:CalculatedAmount')),
+    typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.TaxTypeCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
+    exemptionReason: parseText(get(node, './ram:ExemptionReason')),
+    basisAmount: parseAmount(get(node, './ram:BasisAmount')),
+    lineTotalBasisAmount: parseAmount(get(node, './ram:LineTotalBasisAmount')),
+    allowanceChargeBasisAmount: parseAmount(get(node, './ram:AllowanceChargeBasisAmount')),
+    categoryCode: new qdt.TaxCategoryCodeType({ value: textOf(get(node, './ram:CategoryCode')) ?? '' }),
+    exemptionReasonCode: parseCode(get(node, './ram:ExemptionReasonCode')),
+    taxPointDate: parseDate(get(node, './ram:TaxPointDate')),
+    dueDateTypeCode: textOf(get(node, './ram:DueDateTypeCode')) ? new qdt.TimeReferenceCodeType({ value: textOf(get(node, './ram:DueDateTypeCode'))! }) : undefined,
+    rateApplicablePercent: parsePercent(get(node, './ram:RateApplicablePercent')),
+  })
+}
+
+function parseAllowanceCharge(node: XMLElement): ram.TradeAllowanceChargeType {
+  return new ram.TradeAllowanceChargeType({
+    chargeIndicator: parseIndicator(get(node, './ram:ChargeIndicator')) ?? new udt.IndicatorType({ indicator: false }),
+    sequenceNumeric: textOf(get(node, './ram:SequenceNumeric')) ? new udt.NumericType({ value: Number.parseFloat(textOf(get(node, './ram:SequenceNumeric'))!) }) : undefined,
+    calculationPercent: parsePercent(get(node, './ram:CalculationPercent')),
+    basisAmount: parseAmount(get(node, './ram:BasisAmount')),
+    basisQuantity: parseQuantity(get(node, './ram:BasisQuantity')),
+    actualAmount: parseAmount(get(node, './ram:ActualAmount')) ?? new udt.AmountType({ value: 0 }),
+    reasonCode: textOf(get(node, './ram:ReasonCode')) ? new qdt.AllowanceChargeReasonCodeType({ value: textOf(get(node, './ram:ReasonCode'))! }) : undefined,
+    reason: parseText(get(node, './ram:Reason')),
+    categoryTradeTax: get(node, './ram:CategoryTradeTax') ? parseTradeTax(get(node, './ram:CategoryTradeTax')!) : undefined,
+  })
+}
+
+function parsePaymentTerms(node: XMLElement): ram.TradePaymentTermsType {
+  return new ram.TradePaymentTermsType({
+    description: parseText(get(node, './ram:Description')),
+    dueDateDateTime: parseDateTime(get(node, './ram:DueDateDateTime')),
+    directDebitMandateID: parseID(get(node, './ram:DirectDebitMandateID')),
+    partialPaymentAmount: parseAmount(get(node, './ram:PartialPaymentAmount')),
+    payeeTradeParty: parseTradeParty(get(node, './ram:PayeeTradeParty')),
+  })
+}
+
+function parsePaymentMeans(node: XMLElement): ram.TradeSettlementPaymentMeansType {
+  const card = get(node, './ram:ApplicableTradeSettlementFinancialCard')
+  const debtor = get(node, './ram:PayerPartyDebtorFinancialAccount')
+  const creditor = get(node, './ram:PayeePartyCreditorFinancialAccount')
+  const payerInst = get(node, './ram:PayerSpecifiedDebtorFinancialInstitution')
+  const payeeInst = get(node, './ram:PayeeSpecifiedCreditorFinancialInstitution')
+
+  return new ram.TradeSettlementPaymentMeansType({
+    typeCode: new qdt.PaymentMeansCodeType({ value: textOf(get(node, './ram:TypeCode')) ?? '' }),
+    information: parseText(get(node, './ram:Information')),
+    applicableTradeSettlementFinancialCard: card
+      ? new ram.TradeSettlementFinancialCardType({
+        id: new udt.IDType({ value: textOf(get(card, './ram:ID')) ?? '' }),
+        cardholderName: parseText(get(card, './ram:CardholderName')),
+      })
+      : undefined,
+    payerPartyDebtorFinancialAccount: debtor
+      ? new ram.DebtorFinancialAccountType({
+        ibanID: new udt.IDType({ value: textOf(get(debtor, './ram:IBANID')) ?? '' }),
+        accountName: parseText(get(debtor, './ram:AccountName')),
+      })
+      : undefined,
+    payeePartyCreditorFinancialAccount: creditor
+      ? new ram.CreditorFinancialAccountType({
+        ibanID: parseID(get(creditor, './ram:IBANID')),
+        accountName: parseText(get(creditor, './ram:AccountName')),
+        proprietaryID: parseID(get(creditor, './ram:ProprietaryID')),
+      })
+      : undefined,
+    payerSpecifiedDebtorFinancialInstitution: payerInst
+      ? new ram.DebtorFinancialInstitutionType({ bicID: parseID(get(payerInst, './ram:BICID')) })
+      : undefined,
+    payeeSpecifiedCreditorFinancialInstitution: payeeInst && parseID(get(payeeInst, './ram:BICID'))
+      ? new ram.CreditorFinancialInstitutionType({ bicID: parseID(get(payeeInst, './ram:BICID'))! })
+      : undefined,
+  })
+}
+
+function parseAccountingAccount(node: XMLElement): ram.TradeAccountingAccountType {
+  return new ram.TradeAccountingAccountType({
+    id: new udt.IDType({ value: textOf(get(node, './ram:ID')) ?? '' }),
+    typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.AccountingAccountTypeCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
+  })
+}
+
+function parseReferencedDocument(node: XMLElement | undefined): ram.ReferencedDocumentType | undefined {
+  if (!node) {
+    return undefined
+  }
+  return new ram.ReferencedDocumentType({
+    issuerAssignedID: parseID(get(node, './ram:IssuerAssignedID')),
+    uriID: parseID(get(node, './ram:URIID')),
+    lineID: parseID(get(node, './ram:LineID')),
+    typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.DocumentCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
+    name: findAll(node, './ram:Name').map(n => parseText(n)!),
+    attachmentBinaryObject: parseBinaryObject(get(node, './ram:AttachmentBinaryObject')),
+    referenceTypeCode: textOf(get(node, './ram:ReferenceTypeCode')) ? new qdt.ReferenceCodeType({ value: textOf(get(node, './ram:ReferenceTypeCode'))! }) : undefined,
+    formattedIssueDateTime: parseFormattedDateTime(get(node, './ram:FormattedIssueDateTime')),
   })
 }

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -46,11 +46,17 @@ export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryI
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function get(node: XMLElement, xpath: string): XMLElement | undefined {
+function get(node: XMLElement | undefined, xpath: string): XMLElement | undefined {
+  if (!node) {
+    return undefined
+  }
   return (node.get(xpath, NAMESPACES) as XMLElement) ?? undefined
 }
 
-function findAll(node: XMLElement, xpath: string): XMLElement[] {
+function findAll(node: XMLElement | undefined, xpath: string): XMLElement[] {
+  if (!node) {
+    return []
+  }
   return (node.find(xpath, NAMESPACES) as XMLElement[]) ?? []
 }
 
@@ -247,13 +253,13 @@ function parseLineItem(node: XMLElement): ram.SupplyChainTradeLineItemType {
 
   return new ram.SupplyChainTradeLineItemType({
     associatedDocumentLineDocument: new ram.DocumentLineDocumentType({
-      lineID: new udt.IDType({ value: textOf(get(docLine!, './ram:LineID')) ?? '' }),
-      parentLineID: parseID(get(docLine!, './ram:ParentLineID')),
-      lineStatusCode: textOf(get(docLine!, './ram:LineStatusCode'))
-        ? new qdt.LineStatusCodeType({ value: textOf(get(docLine!, './ram:LineStatusCode'))! })
+      lineID: new udt.IDType({ value: textOf(get(docLine, './ram:LineID')) ?? '' }),
+      parentLineID: parseID(get(docLine, './ram:ParentLineID')),
+      lineStatusCode: textOf(get(docLine, './ram:LineStatusCode'))
+        ? new qdt.LineStatusCodeType({ value: textOf(get(docLine, './ram:LineStatusCode'))! })
         : undefined,
-      lineStatusReasonCode: parseCode(get(docLine!, './ram:LineStatusReasonCode')),
-      includedNote: findAll(docLine!, './ram:IncludedNote').map(parseNote),
+      lineStatusReasonCode: parseCode(get(docLine, './ram:LineStatusReasonCode')),
+      includedNote: findAll(docLine, './ram:IncludedNote').map(parseNote),
     }),
     specifiedTradeProduct: parseTradeProduct(get(node, './ram:SpecifiedTradeProduct')),
     specifiedLineTradeAgreement: parseLineTradeAgreement(get(node, './ram:SpecifiedLineTradeAgreement')),
@@ -605,11 +611,31 @@ function parseAllowanceCharge(node: XMLElement): ram.TradeAllowanceChargeType {
 }
 
 function parsePaymentTerms(node: XMLElement): ram.TradePaymentTermsType {
+  const penalty = get(node, './ram:ApplicableTradePaymentPenaltyTerms')
+  const discount = get(node, './ram:ApplicableTradePaymentDiscountTerms')
   return new ram.TradePaymentTermsType({
     description: parseText(get(node, './ram:Description')),
     dueDateDateTime: parseDateTime(get(node, './ram:DueDateDateTime')),
     directDebitMandateID: parseID(get(node, './ram:DirectDebitMandateID')),
     partialPaymentAmount: parseAmount(get(node, './ram:PartialPaymentAmount')),
+    applicableTradePaymentPenaltyTerms: penalty
+      ? new ram.TradePaymentPenaltyTermsType({
+        basisDateTime: parseDateTime(get(penalty, './ram:BasisDateTime')),
+        basisPeriodMeasure: parseMeasure(get(penalty, './ram:BasisPeriodMeasure')),
+        basisAmount: parseAmount(get(penalty, './ram:BasisAmount')),
+        calculationPercent: parsePercent(get(penalty, './ram:CalculationPercent')),
+        actualPenaltyAmount: parseAmount(get(penalty, './ram:ActualPenaltyAmount')),
+      })
+      : undefined,
+    applicableTradePaymentDiscountTerms: discount
+      ? new ram.TradePaymentDiscountTermsType({
+        basisDateTime: parseDateTime(get(discount, './ram:BasisDateTime')),
+        basisPeriodMeasure: parseMeasure(get(discount, './ram:BasisPeriodMeasure')),
+        basisAmount: parseAmount(get(discount, './ram:BasisAmount')),
+        calculationPercent: parsePercent(get(discount, './ram:CalculationPercent')),
+        actualDiscountAmount: parseAmount(get(discount, './ram:ActualDiscountAmount')),
+      })
+      : undefined,
     payeeTradeParty: parseTradeParty(get(node, './ram:PayeeTradeParty')),
   })
 }

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -93,9 +93,9 @@ describe('facturX XML Converter', () => {
 
     const summation = new TradeSettlementHeaderMonetarySummationType({
       lineTotalAmount,
-      taxBasisTotalAmount: [taxBasisAmount],
+      taxBasisTotalAmount: taxBasisAmount,
       taxTotalAmount: [taxAmount],
-      grandTotalAmount: [grandTotalAmount],
+      grandTotalAmount,
       duePayableAmount,
     })
 
@@ -200,9 +200,9 @@ describe('facturX XML Converter', () => {
 
     const summation = new TradeSettlementHeaderMonetarySummationType({
       lineTotalAmount,
-      taxBasisTotalAmount: [taxBasisAmount],
+      taxBasisTotalAmount: taxBasisAmount,
       taxTotalAmount: [taxAmount],
-      grandTotalAmount: [grandTotalAmount],
+      grandTotalAmount,
       duePayableAmount,
     })
 

--- a/tests/facturx.test.ts
+++ b/tests/facturx.test.ts
@@ -202,9 +202,9 @@ describe('factur-X model', () => {
 
       const summation = new TradeSettlementHeaderMonetarySummationType({
         lineTotalAmount: totalAmount,
-        taxBasisTotalAmount: [taxBasisAmount],
+        taxBasisTotalAmount: taxBasisAmount,
         taxTotalAmount: [taxAmount],
-        grandTotalAmount: [totalAmount],
+        grandTotalAmount: totalAmount,
         duePayableAmount: totalAmount,
       })
 

--- a/tests/fixtures/model-basic.ts
+++ b/tests/fixtures/model-basic.ts
@@ -114,9 +114,9 @@ export function getBasicFacturXModel() {
     lineTotalAmount,
     chargeTotalAmount,
     allowanceTotalAmount,
-    taxBasisTotalAmount: [taxBasisTotalAmount],
+    taxBasisTotalAmount: taxBasisTotalAmount,
     taxTotalAmount: [taxTotalAmount],
-    grandTotalAmount: [grandTotalAmount],
+    grandTotalAmount: grandTotalAmount,
     duePayableAmount,
   })
 

--- a/tests/fixtures/model-basicwl.ts
+++ b/tests/fixtures/model-basicwl.ts
@@ -118,9 +118,9 @@ export function getBasicWLFacturXModel() {
     lineTotalAmount,
     chargeTotalAmount,
     allowanceTotalAmount,
-    taxBasisTotalAmount: [taxBasisTotalAmount],
+    taxBasisTotalAmount: taxBasisTotalAmount,
     taxTotalAmount: [taxTotalAmount],
-    grandTotalAmount: [grandTotalAmount],
+    grandTotalAmount: grandTotalAmount,
     duePayableAmount,
   })
 

--- a/tests/fixtures/model-en16931.ts
+++ b/tests/fixtures/model-en16931.ts
@@ -106,9 +106,9 @@ export function getEN16931FacturXModel() {
 
   const summation = new TradeSettlementHeaderMonetarySummationType({
     lineTotalAmount,
-    taxBasisTotalAmount: [taxBasisTotalAmount],
+    taxBasisTotalAmount: taxBasisTotalAmount,
     taxTotalAmount: [taxTotalAmount],
-    grandTotalAmount: [grandTotalAmount],
+    grandTotalAmount: grandTotalAmount,
     duePayableAmount,
   })
 

--- a/tests/fixtures/model-extended.ts
+++ b/tests/fixtures/model-extended.ts
@@ -6,11 +6,15 @@ import {
   CrossIndustryInvoiceType,
   CurrencyCodeType,
   DateTimeType,
+  DebtorFinancialAccountType,
+  DebtorFinancialInstitutionType,
+  DeliveryTermsCodeType,
   DocumentCodeType,
   DocumentContextParameterType,
   DocumentLineDocumentType,
   ExchangedDocumentContextType,
   ExchangedDocumentType,
+  FinancialAdjustmentType,
   HeaderTradeAgreementType,
   HeaderTradeDeliveryType,
   HeaderTradeSettlementType,
@@ -34,6 +38,8 @@ import {
   TradeAddressType,
   TradeAllowanceChargeType,
   TradeCurrencyExchangeType,
+  TradeDeliveryTermsType,
+  TradeLocationType,
   TradePartyType,
   TradePaymentTermsType,
   TradePriceType,
@@ -168,6 +174,24 @@ export function getExtendedFacturXModel() {
     }),
   })
 
+  // SEPA direct debit means exercising debtor account + financial institution (EXTENDED)
+  const directDebitMeans = new TradeSettlementPaymentMeansType({
+    typeCode: new PaymentMeansCodeType({ value: '59' }),
+    payerPartyDebtorFinancialAccount: new DebtorFinancialAccountType({
+      ibanID: new IDType({ value: 'FR7630006000019876543210123' }),
+      accountName: new TextType({ value: 'Buyer Account' }),
+    }),
+    payerSpecifiedDebtorFinancialInstitution: new DebtorFinancialInstitutionType({
+      bicID: new IDType({ value: 'BNPAFRPP' }),
+    }),
+  })
+
+  // Financial adjustment (EXTENDED)
+  const financialAdjustment = new FinancialAdjustmentType({
+    reason: new TextType({ value: 'Rounding adjustment' }),
+    actualAmount: new AmountType({ value: 0, currencyID: 'EUR' }),
+  })
+
   // Additional taxes
   const vat20 = new TradeTaxType({
     categoryCode: new TaxCategoryCodeType({ value: 'S' }),
@@ -212,9 +236,9 @@ export function getExtendedFacturXModel() {
     lineTotalAmount,
     chargeTotalAmount,
     allowanceTotalAmount,
-    taxBasisTotalAmount: [taxBasisTotalAmount],
+    taxBasisTotalAmount: taxBasisTotalAmount,
     taxTotalAmount: [taxTotalAmount],
-    grandTotalAmount: [grandTotalAmount],
+    grandTotalAmount: grandTotalAmount,
     totalPrepaidAmount,
     duePayableAmount,
   })
@@ -239,14 +263,15 @@ export function getExtendedFacturXModel() {
     paymentReference: new TextType({ value: 'PAYMENT-INV-2023-003' }),
     invoiceCurrencyCode: currencyCode,
     taxCurrencyCode,
-    specifiedTradeSettlementPaymentMeans: [paymentMeans],
+    specifiedTradeSettlementPaymentMeans: [paymentMeans, directDebitMeans],
     applicableTradeTax: [vat20, vat10],
     billingSpecifiedPeriod: effectivePeriod,
     specifiedTradeAllowanceCharge: [headerAllowance],
     taxApplicableTradeCurrencyExchange: currencyExchange,
     specifiedTradeSettlementHeaderMonetarySummation: summation,
-    specifiedTradePaymentTerms: [paymentTerms],
+    specifiedFinancialAdjustment: [financialAdjustment],
     specifiedAdvancePayment: [advancePayment],
+    specifiedTradePaymentTerms: [paymentTerms],
   })
 
   // Line items with more details
@@ -257,8 +282,24 @@ export function getExtendedFacturXModel() {
     specifiedTradeProduct: new TradeProductType({
       globalID: new IDType({ value: '1234567890123', schemeID: 'EAN' }),
       name: new TextType({ value: 'Product 1' }),
+      brandName: new TextType({ value: 'AcmeBrand' }),
+      modelName: new TextType({ value: 'X-2000' }),
+      batchID: [new IDType({ value: 'BATCH-001' })],
+      manufacturerTradeParty: new TradePartyType({
+        name: new TextType({ value: 'Acme Manufacturing' }),
+      }),
     }),
     specifiedLineTradeAgreement: new LineTradeAgreementType({
+      applicableTradeDeliveryTerms: new TradeDeliveryTermsType({
+        deliveryTypeCode: new DeliveryTermsCodeType({ value: 'EXW' }),
+        relevantTradeLocation: new TradeLocationType({
+          countryID: new CountryIDType({ value: 'FR' }),
+          name: new TextType({ value: 'Lyon warehouse' }),
+        }),
+      }),
+      itemSellerTradeParty: new TradePartyType({
+        name: new TextType({ value: 'Reseller SARL' }),
+      }),
       grossPriceProductTradePrice: new TradePriceType({
         chargeAmount: new AmountType({ value: 90, currencyID: 'EUR' }),
       }),
@@ -269,6 +310,7 @@ export function getExtendedFacturXModel() {
     }),
     specifiedLineTradeDelivery: new LineTradeDeliveryType({
       billedQuantity: { value: 1, unitCode: 'C62' },
+      perPackageUnitQuantity: { value: 10, unitCode: 'C62' },
     }),
     specifiedLineTradeSettlement: new LineTradeSettlementType({
       applicableTradeTax: [new TradeTaxType({

--- a/tests/fixtures/model-extended.ts
+++ b/tests/fixtures/model-extended.ts
@@ -41,6 +41,8 @@ import {
   TradeDeliveryTermsType,
   TradeLocationType,
   TradePartyType,
+  TradePaymentDiscountTermsType,
+  TradePaymentPenaltyTermsType,
   TradePaymentTermsType,
   TradePriceType,
   TradeProductType,
@@ -182,7 +184,7 @@ export function getExtendedFacturXModel() {
       accountName: new TextType({ value: 'Buyer Account' }),
     }),
     payerSpecifiedDebtorFinancialInstitution: new DebtorFinancialInstitutionType({
-      bicID: new IDType({ value: 'BNPAFRPP' }),
+      bicID: new IDType({ value: 'BNPAFRPP', schemeID: 'BIC' }),
     }),
   })
 
@@ -246,6 +248,14 @@ export function getExtendedFacturXModel() {
   const paymentTerms = new TradePaymentTermsType({
     description: new TextType({ value: 'Payment due within 30 days' }),
     dueDateDateTime: new DateTimeType({ dateTimeString: '20230515', format: '102' }),
+    applicableTradePaymentPenaltyTerms: new TradePaymentPenaltyTermsType({
+      calculationPercent: { value: 5 },
+      actualPenaltyAmount: new AmountType({ value: 2, currencyID: 'EUR' }),
+    }),
+    applicableTradePaymentDiscountTerms: new TradePaymentDiscountTermsType({
+      calculationPercent: { value: 2 },
+      actualDiscountAmount: new AmountType({ value: 1, currencyID: 'EUR' }),
+    }),
   })
 
   // Advance payment info

--- a/tests/fixtures/model-minimal.ts
+++ b/tests/fixtures/model-minimal.ts
@@ -83,9 +83,9 @@ export function getMinimalFacturXModel() {
 
   const summation = new TradeSettlementHeaderMonetarySummationType({
     // lineTotalAmount: new AmountType({ value: 100, currencyID: 'EUR' }),
-    taxBasisTotalAmount: [taxBasisTotalAmount],
+    taxBasisTotalAmount: taxBasisTotalAmount,
     taxTotalAmount: [taxTotalAmount],
-    grandTotalAmount: [grandTotalAmount],
+    grandTotalAmount: grandTotalAmount,
     duePayableAmount,
   })
 

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -1,4 +1,4 @@
-import { check, invoiceToXml } from '@stafyniaksacha/facturx'
+import { check, invoiceToXml, xmlToInvoice } from '@stafyniaksacha/facturx'
 import { describe, expect, it, vi } from 'vitest'
 import { getBasicFacturXModel } from './fixtures/model-basic'
 import { getBasicWLFacturXModel } from './fixtures/model-basicwl'
@@ -125,5 +125,51 @@ describe('invoiceToXml', () => {
     expect(result.errors.length).toBeGreaterThan(0)
     expect(result.flavor).toBe('facturx')
     expect(result.level).toBe('extended')
+  })
+
+  it('should emit the EXTENDED-only aggregates and stay valid', async () => {
+    const xml = (await invoiceToXml(getExtendedFacturXModel())).toString()
+
+    // New 1.09 EXTENDED types added in this upgrade
+    expect(xml).toContain('<ram:SpecifiedFinancialAdjustment>')
+    expect(xml).toContain('<ram:PayerSpecifiedDebtorFinancialInstitution>')
+    expect(xml).toContain('<ram:RelevantTradeLocation>')
+    expect(xml).toContain('<ram:ManufacturerTradeParty>')
+    expect(xml).toContain('<ram:BrandName>')
+    expect(xml).toContain('<ram:ModelName>')
+    expect(xml).toContain('<ram:ItemSellerTradeParty>')
+    expect(xml).toContain('<ram:PerPackageUnitQuantity')
+    expect(xml).toContain('<ram:ApplicableTradeDeliveryTerms>')
+
+    const result = await check({ xml, flavor: 'facturx', level: 'extended' })
+    expect(result.errors).toStrictEqual([])
+    expect(result.valid).toBe(true)
+  })
+})
+
+describe('round-trip fidelity (model → xml → model → xml)', () => {
+  const cases: [string, () => any][] = [
+    ['minimum', getMinimalFacturXModel],
+    ['basicwl', getBasicWLFacturXModel],
+    ['basic', getBasicFacturXModel],
+    ['en16931', getEN16931FacturXModel],
+    ['extended', getExtendedFacturXModel],
+  ]
+
+  const count = (s: string, tag: string): number => (s.match(new RegExp(`<ram:${tag}[ >]`, 'g')) || []).length
+
+  it.each(cases)('round-trips a %s invoice without losing structure', async (level, factory) => {
+    const xml1 = (await invoiceToXml(factory())).toString()
+    const xml2 = (await invoiceToXml(await xmlToInvoice(xml1))).toString()
+
+    // Re-parsed + re-serialised output must still validate at the same level
+    const result = await check({ xml: xml2, flavor: 'facturx', level })
+    expect(result.errors).toStrictEqual([])
+    expect(result.valid).toBe(true)
+
+    // Key repeating aggregates must survive the round-trip
+    for (const tag of ['IncludedSupplyChainTradeLineItem', 'ApplicableTradeTax', 'SpecifiedTradePaymentTerms', 'SpecifiedTradeSettlementPaymentMeans']) {
+      expect(count(xml2, tag)).toBe(count(xml1, tag))
+    }
   })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -11,6 +11,7 @@ import {
 import { parseXmlAsync } from 'libxmljs'
 import { describe, expect, it } from 'vitest'
 
+import { getExtendedFacturXModel } from './fixtures/model-extended'
 import { getEN16931XML, getMinimumXML } from './fixtures/xml'
 
 describe('facturX XML Parser', () => {
@@ -151,5 +152,43 @@ describe('facturX XML Parser', () => {
   it('should handle invalid XML gracefully', async () => {
     const invalidXml = '<invalid>XML</invalid>'
     await expect(xmlToInvoice(invalidXml)).rejects.toThrow()
+  })
+})
+
+describe('facturX XML Parser — robustness & round-trip', () => {
+  it('round-trips payment penalty/discount terms and a BIC schemeID', async () => {
+    const xml = (await invoiceToXml(getExtendedFacturXModel())).toString()
+    const invoice = await xmlToInvoice(xml)
+
+    const terms = invoice.supplyChainTradeTransaction.applicableHeaderTradeSettlement.specifiedTradePaymentTerms?.[0]
+    expect(terms?.applicableTradePaymentPenaltyTerms?.actualPenaltyAmount?.value).toBe(2)
+    expect(terms?.applicableTradePaymentDiscountTerms?.actualDiscountAmount?.value).toBe(1)
+
+    const means = invoice.supplyChainTradeTransaction.applicableHeaderTradeSettlement.specifiedTradeSettlementPaymentMeans ?? []
+    const bic = means.map(m => m.payerSpecifiedDebtorFinancialInstitution?.bicID).find(Boolean)
+    expect(bic?.value).toBe('BNPAFRPP')
+    expect(bic?.schemeID).toBe('BIC')
+  })
+
+  it('does not crash on a line item missing AssociatedDocumentLineDocument', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext><ram:GuidelineSpecifiedDocumentContextParameter><ram:ID>urn:cen.eu:en16931:2017</ram:ID></ram:GuidelineSpecifiedDocumentContextParameter></rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument><ram:ID>X</ram:ID><ram:TypeCode>380</ram:TypeCode><ram:IssueDateTime><udt:DateTimeString format="102">20230101</udt:DateTimeString></ram:IssueDateTime></rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:SpecifiedTradeProduct><ram:Name>Item</ram:Name></ram:SpecifiedTradeProduct>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement><ram:SellerTradeParty><ram:Name>S</ram:Name></ram:SellerTradeParty><ram:BuyerTradeParty><ram:Name>B</ram:Name></ram:BuyerTradeParty></ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery/>
+    <ram:ApplicableHeaderTradeSettlement><ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode><ram:SpecifiedTradeSettlementHeaderMonetarySummation><ram:TaxBasisTotalAmount>0</ram:TaxBasisTotalAmount><ram:GrandTotalAmount>0</ram:GrandTotalAmount><ram:DuePayableAmount>0</ram:DuePayableAmount></ram:SpecifiedTradeSettlementHeaderMonetarySummation></ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>`
+
+    const invoice = await xmlToInvoice(xml)
+    const line = invoice.supplyChainTradeTransaction.includedSupplyChainTradeLineItem?.[0]
+    // missing AssociatedDocumentLineDocument degrades to an empty lineID instead of throwing
+    expect(line?.associatedDocumentLineDocument.lineID.value).toBe('')
+    expect(line?.specifiedTradeProduct.name.value).toBe('Item')
   })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -103,8 +103,8 @@ describe('facturX XML Parser', () => {
     // Check monetary summation
     const summation = settlement.specifiedTradeSettlementHeaderMonetarySummation
 
-    if (summation.taxBasisTotalAmount && summation.taxBasisTotalAmount.length > 0) {
-      expect(summation.taxBasisTotalAmount[0].value).toBe(624.9)
+    if (summation.taxBasisTotalAmount) {
+      expect(summation.taxBasisTotalAmount.value).toBe(624.9)
     }
 
     if (summation.taxTotalAmount && summation.taxTotalAmount.length > 0) {
@@ -112,8 +112,8 @@ describe('facturX XML Parser', () => {
       // Don't check currencyID as it may not be properly set by the parser
     }
 
-    if (summation.grandTotalAmount && summation.grandTotalAmount.length > 0) {
-      expect(summation.grandTotalAmount[0].value).toBe(671.15)
+    if (summation.grandTotalAmount) {
+      expect(summation.grandTotalAmount.value).toBe(671.15)
     }
 
     expect(summation.duePayableAmount.value).toBe(470.15)
@@ -137,8 +137,8 @@ describe('facturX XML Parser', () => {
       expect(summation.lineTotalAmount.value).toBe(624.9)
     }
 
-    if (summation.taxBasisTotalAmount && summation.taxBasisTotalAmount.length > 0) {
-      expect(summation.taxBasisTotalAmount[0].value).toBe(624.9)
+    if (summation.taxBasisTotalAmount) {
+      expect(summation.taxBasisTotalAmount.value).toBe(624.9)
     }
 
     if (summation.totalPrepaidAmount) {


### PR DESCRIPTION
**Phase 2 of 3** of the Factur-X 1.09 upgrade. Stacked on top of #8 (base: `feat/facturx-1.09-phase1`).

**Models**
- Add missing 1.09 EXTENDED types: `FinancialAdjustmentType`, `TradeLocationType`, `DebtorFinancialInstitutionType`.
- Add missing fields (financial adjustment, payer debtor institution, debtor account name, line delivery terms / seller-order ref / item-seller party, per-package quantity, product industry/model/batch/brand/model-name/manufacturer, relevant trade location, advance-payment ref).
- Cardinality fixes to match 1.09 (header monetary summation `TaxBasisTotalAmount`/`GrandTotalAmount` single, `TaxTotalAmount` 0..2; settlement/line refs and accounting accounts as arrays; optional line agreement/delivery & net price).
  ⚠️ **Breaking:** the two monetary fields change from array to single.

**Converter** rewritten to emit every model field in the exact 1.09 EXTENDED `xs:sequence` order (parties incl. ids/contacts/uri/legal org, full addresses, referenced documents incl. attachments, product metadata, delivery, payment means IBAN/BIC/card, allowance/charge with tax category, payment terms, logistics charges, financial adjustments, advance payments, currency exchange).

**Parser** rewritten symmetric to the converter — parses line items (previously dropped entirely), delivery, payment means, taxes, allowances, payment terms and references; reads the real date format attribute and tax-registration schemeID.

**Tests:** enrich the EXTENDED fixture with the new aggregates; add round-trip fidelity tests for all five profiles. Verified against the spec's **real example PDFs** (MINIMUM→EXTENDED): extract → validate → parse → re-serialise stays schema-valid with all line/tax/allowance counts and totals preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)