### PR TITLE
feat: replace `libxmljs` with `libxml2-wasm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Factur-X and Order-X JS library
 
-Generate, extract, parse and validate Factur-X / ZUGFeRD and Order-X e-invoices in TypeScript, using [pdf-lib](https://github.com/Hopding/pdf-lib) and [libxmljs](https://github.com/libxmljs/libxmljs).
+Generate, extract, parse and validate Factur-X / ZUGFeRD and Order-X e-invoices in TypeScript, using [pdf-lib](https://github.com/Hopding/pdf-lib) and [libxml2-wasm](https://github.com/jameslan/libxml2-wasm).
 
 Conforms to **Factur-X 1.09 / ZUGFeRD 2.5** (the EN 16931 European e-invoicing standard, CII D22B).
 

--- a/docs/api/check.md
+++ b/docs/api/check.md
@@ -7,7 +7,7 @@ business rules.
 
 ```ts
 function check(options: {
-  xml: string | Buffer | XMLDocument
+  xml: string | Buffer | XmlDocument
   flavor?: string
   level?: string
   schematron?: boolean
@@ -25,7 +25,7 @@ function check(options: {
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `xml` | `string \| Buffer \| XMLDocument` | — | **Required.** The invoice XML. |
+| `xml` | `string \| Buffer \| XmlDocument` | — | **Required.** The invoice XML. |
 | `flavor` | `string` | autodetect | `facturx`, `orderx` or `zugferd`. |
 | `level` | `string` | autodetect | Schema level (e.g. `en16931`). |
 | `schematron` | `boolean` | `false` | Also run Schematron business-rule validation. **Factur-X only** — throws otherwise. |

--- a/docs/api/generate.md
+++ b/docs/api/generate.md
@@ -7,7 +7,7 @@ Embed an XML invoice into a PDF and return a compliant **PDF/A-3** as bytes.
 ```ts
 function generate(options: {
   pdf: string | Buffer | PDFDocument
-  xml: string | Buffer | XMLDocument
+  xml: string | Buffer | XmlDocument
   check?: boolean
   flavor?: string
   level?: string
@@ -21,7 +21,7 @@ function generate(options: {
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pdf` | `string \| Buffer \| PDFDocument` | — | **Required.** Source PDF (path/bytes already read, or a `pdf-lib` document). |
-| `xml` | `string \| Buffer \| XMLDocument` | — | **Required.** Invoice XML to embed. |
+| `xml` | `string \| Buffer \| XmlDocument` | — | **Required.** Invoice XML to embed. |
 | `check` | `boolean` | `false` | Set `true` to run XSD validation before embedding; throws on invalid XML. |
 | `flavor` | `string` | autodetect | `facturx`, `orderx` or `zugferd`. |
 | `level` | `string` | autodetect | Schema level (e.g. `en16931`). |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -35,7 +35,7 @@ import { AmountType, CrossIndustryInvoiceType, IDType /* … */ } from '@stafyni
 | [`check(options)`](/api/check) | `() => Promise<CheckResult>` | XSD (+ optional Schematron) validation. |
 | [`validateSchematron(options)`](/api/validate-schematron) | `() => Promise<{ valid, errors }>` | EN 16931 business-rule validation (Factur-X only). |
 | [`xmlToInvoice(xml)`](/api/parsing) | `() => Promise<CrossIndustryInvoiceType>` | Parse XML into a typed model. |
-| [`invoiceToXml(invoice)`](/api/parsing) | `() => Promise<XMLDocument>` | Serialize a model back to XML. |
+| [`invoiceToXml(invoice)`](/api/parsing) | `() => Promise<XmlDocument>` | Serialize a model back to XML. |
 | [`Models`](/api/models) | namespace | All Cross Industry Invoice model classes & types. |
 
 ## Typical flows
@@ -71,6 +71,6 @@ const seller = invoice.supplyChainTradeTransaction
 
 - **`flavor` / `level`** are optional on every function that takes XML — they're
   [autodetected](/guide/profiles-and-flavors#autodetection) from the document when omitted.
-- **Inputs** accept `string | Buffer` (and `generate`/`check` also accept a parsed `XMLDocument`;
+- **Inputs** accept `string | Buffer` (and `generate`/`check` also accept a parsed `XmlDocument`;
   `generate`/`extract` also accept a `PDFDocument`).
 - **Errors** are thrown as standard `Error`s (e.g. `No attachment found`, `Invalid XML`).

--- a/docs/api/parsing.md
+++ b/docs/api/parsing.md
@@ -25,7 +25,7 @@ Throws `Invalid XML: no root element` if the input has no document root.
 ## `invoiceToXml()`
 
 ```ts
-function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<XMLDocument>
+function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<XmlDocument>
 ```
 
 Serializes a `CrossIndustryInvoiceType` model back to XML. Element order follows the `xs:sequence`
@@ -33,7 +33,7 @@ of the Factur-X 1.09 (CII D22B) **EXTENDED** schema — a superset of all lower 
 fields present on the model are emitted, so the same converter produces valid output for every
 profile from `MINIMUM` to `EXTENDED`.
 
-The return value is a `libxmljs` `XMLDocument`; call `.toString()` for the serialized XML.
+The return value is a `libxml2-wasm` `XmlDocument`; call `.toString()` for the serialized XML.
 
 ```ts
 import { invoiceToXml } from '@stafyniaksacha/facturx'

--- a/docs/api/parsing.md
+++ b/docs/api/parsing.md
@@ -42,6 +42,23 @@ const doc = await invoiceToXml(invoice)
 const xmlString = doc.toString()
 ```
 
+The returned `XmlDocument` holds WebAssembly-allocated memory that is not
+garbage-collected. Free it explicitly when you are done:
+
+```ts
+doc.dispose()
+```
+
+Or use a TypeScript 5.2 `using` declaration to dispose it automatically at the
+end of the block:
+
+```ts
+using doc = await invoiceToXml(invoice)
+// doc is automatically disposed at the end of this block
+```
+
+See the [libxml2-wasm memory management docs](https://jameslan.github.io/libxml2-wasm/v0.7/documents/Memory_Management.html#object-disposal) for details.
+
 ## Round-trip
 
 Because the parser and converter mirror each other, you can read, modify and re-serialize:

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@pdf-lib/fontkit": "^1.1.1",
     "citty": "^0.2.2",
     "date-fns": "^4.1.0",
-    "libxmljs": "^1.0.11",
+    "libxml2-wasm": "^0.7.1",
     "pdf-lib": "^1.17.1",
     "saxon-js": "^2.7.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.4.0
-      libxmljs:
-        specifier: ^1.0.11
-        version: 1.0.11
+      libxml2-wasm:
+        specifier: ^0.7.1
+        version: 0.7.1
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -618,10 +618,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@mapbox/node-pre-gyp@1.0.11':
-    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
-    hasBin: true
-
   '@ota-meshi/ast-token-store@0.3.0':
     resolution: {integrity: sha512-XRO0zi2NIUKq2lUk3T1ecFSld1fMWRKE6naRFGkgkdeosx7IslyUKNv5Dcb5PJTja9tHJoFu0v/7yEpAkrkrTg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1148,9 +1144,6 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1168,25 +1161,13 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
-  aproba@2.1.0:
-    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
-
-  are-we-there-yet@2.0.0:
-    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1208,9 +1189,6 @@ packages:
   axios@1.18.0:
     resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1220,17 +1198,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  bindings@1.3.1:
-    resolution: {integrity: sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==}
-
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1278,10 +1250,6 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
@@ -1298,10 +1266,6 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
-
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1333,9 +1297,6 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1345,9 +1306,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1439,16 +1397,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1476,9 +1427,6 @@ packages:
 
   electron-to-chromium@1.5.376:
     resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -1827,13 +1775,6 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1841,11 +1782,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  gauge@3.0.2:
-    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1864,10 +1800,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
@@ -1898,9 +1830,6 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
-
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -1944,13 +1873,6 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -1962,10 +1884,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2046,9 +1964,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libxmljs@1.0.11:
-    resolution: {integrity: sha512-ChqXkhZuvhbjariwPakKs/h+dF5Pe7j+QJ/PmTidzx7mDiFa5chhy7806PQiO+VnBJZ5mVLVq4Dk+W7fZP6luw==}
-    engines: {node: '>=0.8.0'}
+  libxml2-wasm@0.7.1:
+    resolution: {integrity: sha512-aZpJJL/j6T3D+5TmhG4D0ylR3mN6UzmqmBjyb/p+zEAaouG6GpfHiUNUzKR3vKCEoJt/Z2L15XPDCVPuFJIQhg==}
+    engines: {node: '>=18'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2079,10 +1997,6 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
-
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2248,28 +2162,8 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   mkdist@2.4.1:
     resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
@@ -2301,9 +2195,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nan@2.27.0:
-    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
-
   nanoid@3.3.13:
     resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2316,34 +2207,12 @@ packages:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-releases@2.0.48:
     resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
     engines: {node: '>=18'}
 
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  npmlog@5.0.1:
-    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
-    deprecated: This package is no longer supported.
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
 
   object-deep-merge@2.0.1:
     resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
@@ -2351,9 +2220,6 @@ packages:
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
@@ -2395,10 +2261,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2637,10 +2499,6 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
   refa@0.12.1:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2678,11 +2536,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rollup-plugin-dts@6.4.1:
     resolution: {integrity: sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==}
     engines: {node: '>=20'}
@@ -2694,9 +2547,6 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -2712,17 +2562,10 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2737,9 +2580,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -2766,19 +2606,8 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
 
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
@@ -2814,11 +2643,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2841,9 +2665,6 @@ packages:
   toml-eslint-parser@1.0.3:
     resolution: {integrity: sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3034,12 +2855,6 @@ packages:
       typescript:
         optional: true
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3050,15 +2865,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -3067,9 +2876,6 @@ packages:
   xslt3@2.7.0:
     resolution: {integrity: sha512-Vt32LhCt4CQULtGPWlGW++PhS+o3LA6z3PDvig9lDfbo2cIHcaEnyrRYDTilw4N0EbAyxCaw5E0B+DICZEYktQ==}
     hasBin: true
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml-eslint-parser@2.0.0:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
@@ -3471,21 +3277,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@mapbox/node-pre-gyp@1.0.11':
-    dependencies:
-      detect-libc: 2.1.2
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.7.0
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.8.4
-      tar: 6.2.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@ota-meshi/ast-token-store@0.3.0': {}
 
@@ -4003,8 +3794,6 @@ snapshots:
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  abbrev@1.1.1: {}
-
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -4024,18 +3813,9 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-regex@5.0.1: {}
-
   ansis@4.3.1: {}
 
-  aproba@2.1.0: {}
-
   are-docs-informative@0.0.2: {}
-
-  are-we-there-yet@2.0.0:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
 
   assertion-error@2.0.1: {}
 
@@ -4066,22 +3846,13 @@ snapshots:
       - debug
       - supports-color
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.38: {}
 
-  bindings@1.3.1: {}
-
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
-
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -4125,8 +3896,6 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chownr@2.0.0: {}
-
   ci-info@4.4.0: {}
 
   citty@0.1.6:
@@ -4140,8 +3909,6 @@ snapshots:
       escape-string-regexp: 1.0.5
 
   code-block-writer@13.0.3: {}
-
-  color-support@1.1.3: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -4161,15 +3928,11 @@ snapshots:
 
   commondir@1.0.1: {}
 
-  concat-map@0.0.1: {}
-
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
-
-  console-control-strings@1.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4277,11 +4040,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  delegates@1.0.0: {}
-
   dequal@2.0.3: {}
-
-  detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
@@ -4314,8 +4073,6 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.376: {}
-
-  emoji-regex@8.0.0: {}
 
   empathic@2.0.1: {}
 
@@ -4758,28 +4515,10 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
-
-  gauge@3.0.2:
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      object-assign: 4.1.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4809,15 +4548,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
   globals@15.15.0: {}
 
   globals@17.6.0: {}
@@ -4835,8 +4565,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  has-unicode@2.0.1: {}
 
   hasown@2.0.4:
     dependencies:
@@ -4883,13 +4611,6 @@ snapshots:
 
   indent-string@5.0.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
-
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.2.0
@@ -4899,8 +4620,6 @@ snapshots:
       hasown: 2.0.4
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -4969,14 +4688,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libxmljs@1.0.11:
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
-      bindings: 1.3.1
-      nan: 2.27.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+  libxml2-wasm@0.7.1: {}
 
   lilconfig@3.1.3: {}
 
@@ -5007,10 +4719,6 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
-
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
 
   make-dir@4.0.0:
     dependencies:
@@ -5381,24 +5089,7 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.15
-
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minisearch@7.2.0: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
-  mkdirp@1.0.4: {}
 
   mkdist@2.4.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)):
     dependencies:
@@ -5430,44 +5121,21 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nan@2.27.0: {}
-
   nanoid@3.3.13: {}
 
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-releases@2.0.48: {}
-
-  nopt@5.0.0:
-    dependencies:
-      abbrev: 1.1.1
-
-  npmlog@5.0.1:
-    dependencies:
-      are-we-there-yet: 2.0.0
-      console-control-strings: 1.1.0
-      gauge: 3.0.2
-      set-blocking: 2.0.0
 
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
-  object-assign@4.1.1: {}
-
   object-deep-merge@2.0.1: {}
 
   obug@2.1.3: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   oniguruma-parser@0.12.2: {}
 
@@ -5509,8 +5177,6 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -5730,12 +5396,6 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
   refa@0.12.1:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5771,10 +5431,6 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
 
   rollup-plugin-dts@6.4.1(rollup@4.62.2)(typescript@6.0.3):
     dependencies:
@@ -5818,8 +5474,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
-  safe-buffer@5.2.1: {}
-
   sax@1.6.0: {}
 
   saxon-js@2.7.0:
@@ -5837,11 +5491,7 @@ snapshots:
 
   scule@1.3.0: {}
 
-  semver@6.3.1: {}
-
   semver@7.8.4: {}
-
-  set-blocking@2.0.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5862,8 +5512,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7: {}
-
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
@@ -5883,24 +5531,10 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
 
   strip-indent@4.1.1: {}
 
@@ -5934,15 +5568,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -5962,8 +5587,6 @@ snapshots:
   toml-eslint-parser@1.0.3:
     dependencies:
       eslint-visitor-keys: 5.0.1
-
-  tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
 
@@ -6192,13 +5815,6 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -6208,13 +5824,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
-
   word-wrap@1.2.5: {}
-
-  wrappy@1.0.2: {}
 
   xml-name-validator@4.0.0: {}
 
@@ -6225,8 +5835,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  yallist@4.0.0: {}
 
   yaml-eslint-parser@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,3 @@ packages:
 
 allowBuilds:
   esbuild: true
-  libxmljs: true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { runMain as _runMain, defineCommand } from 'citty'
-import pkg from '../package.json' assert { type: 'json' }
+import pkg from '../package.json' with { type: 'json' }
 
 export const main = defineCommand({
   meta: {

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -46,6 +46,13 @@ export async function check(options: {
     }
   }
 
+  const xmlString = xml.toString()
+
+  if (!(options.xml instanceof XmlDocument)) {
+    // Dispose the XmlDocument instance if we created it within this function
+    xml.dispose()
+  }
+
   if (!options.schematron) {
     return {
       valid: xsdValid,
@@ -55,12 +62,7 @@ export async function check(options: {
     }
   }
 
-  const schematron = await validateSchematron({ xml: xml.toString(), flavor, level })
-
-  if (!(options.xml instanceof XmlDocument)) {
-    // Dispose the XmlDocument instance if we created it within this function
-    xml.dispose()
-  }
+  const schematron = await validateSchematron({ xml: xmlString, flavor, level })
 
   return {
     valid: xsdValid && schematron.valid,

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -1,9 +1,6 @@
-import type { XmlDocument } from 'libxml2-wasm'
-
 import type { Buffer } from 'node:buffer'
 import type { SchematronError } from './schematron'
-
-import { XmlValidateError, XsdValidator } from 'libxml2-wasm'
+import { XmlDocument, XmlValidateError, XsdValidator } from 'libxml2-wasm'
 import { resolveXml } from './resolve'
 import { validateSchematron } from './schematron'
 import { getFlavor, getLevel } from './xml'
@@ -62,6 +59,11 @@ export async function check(options: {
   }
 
   const schematron = await validateSchematron({ xml: xml.toString(), flavor, level })
+
+  if (!(options.xml instanceof XmlDocument)) {
+    // Dispose the XmlDocument instance if we created it within this function
+    xml.dispose()
+  }
 
   return {
     valid: xsdValid && schematron.valid,

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -29,7 +29,7 @@ export async function check(options: {
   const level = options.level || getLevel(xml)
 
   const xsd = await getXsd(flavor, level)
-  const validator = XsdValidator.fromDoc(xsd)
+  using validator = XsdValidator.fromDoc(xsd)
 
   let xsdValid = false
   let errors: any[] = []
@@ -44,9 +44,6 @@ export async function check(options: {
     else {
       throw error
     }
-  }
-  finally {
-    validator.dispose()
   }
 
   if (!options.schematron) {

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -1,15 +1,16 @@
-import type { XMLDocument } from 'libxmljs'
+import type { XmlDocument } from 'libxml2-wasm'
 
 import type { Buffer } from 'node:buffer'
 import type { SchematronError } from './schematron'
 
+import { XmlValidateError, XsdValidator } from 'libxml2-wasm'
 import { resolveXml } from './resolve'
 import { validateSchematron } from './schematron'
 import { getFlavor, getLevel } from './xml'
 import { getXsd } from './xsd'
 
 export async function check(options: {
-  xml: string | Buffer | XMLDocument
+  xml: string | Buffer | XmlDocument
   flavor?: string
   level?: string
   /**
@@ -31,9 +32,22 @@ export async function check(options: {
   const level = options.level || getLevel(xml)
 
   const xsd = await getXsd(flavor, level)
+  const validator = XsdValidator.fromDoc(xsd)
 
-  const xsdValid = xml.validate(xsd) as boolean
-  const errors = xml.validationErrors
+  let xsdValid = false
+  let errors: any[] = []
+  try {
+    validator.validate(xml)
+    xsdValid = true
+  }
+  catch (error) {
+    if (error instanceof XmlValidateError) {
+      errors = error.details
+    }
+  }
+  finally {
+    validator.dispose()
+  }
 
   if (!options.schematron) {
     return {

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -44,6 +44,9 @@ export async function check(options: {
     if (error instanceof XmlValidateError) {
       errors = error.details
     }
+    else {
+      throw error
+    }
   }
   finally {
     validator.dispose()

--- a/src/lib/converters/facturx.ts
+++ b/src/lib/converters/facturx.ts
@@ -1,4 +1,4 @@
-import type { XMLDocument, XMLElement } from 'libxmljs'
+import type { XmlElement } from 'libxml2-wasm'
 import type {
   CrossIndustryInvoiceType,
   ExchangedDocumentContextType,
@@ -10,7 +10,7 @@ import type {
 } from '../models/facturx/crossIndustryInvoice'
 import type * as ram from '../models/facturx/reusableTypes'
 import type * as udt from '../models/facturx/unqualifiedTypes'
-import { parseXmlAsync } from 'libxmljs'
+import { XmlDocument } from 'libxml2-wasm'
 
 /**
  * Converter for FacturX CrossIndustryInvoice model to XML.
@@ -20,7 +20,7 @@ import { parseXmlAsync } from 'libxmljs'
  * are present on the model are emitted, so the same converter produces valid
  * output for MINIMUM through EXTENDED.
  */
-export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<XMLDocument> {
+export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<XmlDocument> {
   const xmlString = `<?xml version="1.0" encoding="UTF-8"?>
 <rsm:CrossIndustryInvoice
   xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
@@ -30,8 +30,8 @@ export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<X
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 </rsm:CrossIndustryInvoice>`
 
-  const doc = await parseXmlAsync(xmlString)
-  const rootElement = doc.root() as XMLElement
+  const doc = XmlDocument.fromString(xmlString)
+  const rootElement = doc.root
 
   convertExchangedDocumentContext(invoice.exchangedDocumentContext, rootElement)
   convertExchangedDocument(invoice.exchangedDocument, rootElement)
@@ -44,84 +44,88 @@ export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<X
 // Primitive (Unqualified / Qualified data type) converters
 // ---------------------------------------------------------------------------
 
-function convertAmount({ value, currencyID }: udt.AmountType, parent: XMLElement): XMLElement {
-  parent.text(value.toFixed(2))
+function convertAmount({ value, currencyID }: udt.AmountType, parent: XmlElement): XmlElement {
+  parent.addText(value.toFixed(2))
   if (currencyID) {
-    parent.attr({ currencyID })
+    parent.setAttr('currencyID', currencyID)
   }
   return parent
 }
 
-function convertID({ value, schemeID }: udt.IDType, parent: XMLElement): XMLElement {
-  parent.text(value)
+function convertID({ value, schemeID }: udt.IDType, parent: XmlElement): XmlElement {
+  parent.addText(value)
   if (schemeID) {
-    parent.attr({ schemeID })
+    parent.setAttr('schemeID', schemeID)
   }
   return parent
 }
 
-function convertText({ value }: udt.TextType, parent: XMLElement): XMLElement {
-  parent.text(value)
+function convertText({ value }: udt.TextType, parent: XmlElement): XmlElement {
+  parent.addText(value)
   return parent
 }
 
-function convertCode({ value, listID, listVersionID }: udt.CodeType, parent: XMLElement): XMLElement {
-  parent.text(value)
+function convertCode({ value, listID, listVersionID }: udt.CodeType, parent: XmlElement): XmlElement {
+  parent.addText(value)
   if (listID) {
-    parent.attr({ listID })
+    parent.setAttr('listID', listID)
   }
   if (listVersionID) {
-    parent.attr({ listVersionID })
+    parent.setAttr('listVersionID', listVersionID)
   }
   return parent
 }
 
-function convertQuantity({ value, unitCode }: udt.QuantityType, parent: XMLElement): XMLElement {
-  parent.text(String(value))
+function convertQuantity({ value, unitCode }: udt.QuantityType, parent: XmlElement): XmlElement {
+  parent.addText(String(value))
   if (unitCode) {
-    parent.attr({ unitCode })
+    parent.setAttr('unitCode', unitCode)
   }
   return parent
 }
 
-function convertMeasure({ value, unitCode }: udt.MeasureType, parent: XMLElement): XMLElement {
-  parent.text(String(value))
+function convertMeasure({ value, unitCode }: udt.MeasureType, parent: XmlElement): XmlElement {
+  parent.addText(String(value))
   if (unitCode) {
-    parent.attr({ unitCode })
+    parent.setAttr('unitCode', unitCode)
   }
   return parent
 }
 
-function convertDateTime({ dateTimeString, format }: udt.DateTimeType, parent: XMLElement): XMLElement {
-  const el = parent.node('udt:DateTimeString', dateTimeString)
-  el.attr({ format })
+function convertDateTime({ dateTimeString, format }: udt.DateTimeType, parent: XmlElement): XmlElement {
+  const el = parent.addElement('udt:DateTimeString')
+  el.addText(dateTimeString)
+  el.setAttr('format', format)
   return parent
 }
 
-function convertDate({ dateString, format }: udt.DateType, parent: XMLElement): XMLElement {
-  const el = parent.node('udt:DateString', dateString)
-  el.attr({ format })
+function convertDate({ dateString, format }: udt.DateType, parent: XmlElement): XmlElement {
+  const el = parent.addElement('udt:DateString')
+  el.addText(dateString)
+  el.setAttr('format', format)
   return parent
 }
 
 /** FormattedDateTimeType uses the qdt:DateTimeString element (qualified namespace). */
 function convertFormattedDateTime(
   { dateTimeString, format }: { dateTimeString: string, format: string },
-  parent: XMLElement,
-): XMLElement {
-  const el = parent.node('qdt:DateTimeString', dateTimeString)
-  el.attr({ format })
+  parent: XmlElement,
+): XmlElement {
+  const el = parent.addElement('qdt:DateTimeString')
+  el.addText(dateTimeString)
+  el.setAttr('format', format)
   return parent
 }
 
-function convertIndicator({ indicator }: udt.IndicatorType, parent: XMLElement): XMLElement {
-  parent.node('udt:Indicator', String(indicator))
+function convertIndicator({ indicator }: udt.IndicatorType, parent: XmlElement): XmlElement {
+  parent.addElement('udt:Indicator').addText(String(indicator))
   return parent
 }
 
-function convertBinaryObject({ value, mimeCode, filename }: udt.BinaryObjectType, parent: XMLElement): XMLElement {
-  parent.text(value)
-  parent.attr({ mimeCode, filename })
+function convertBinaryObject({ value, mimeCode, filename }: udt.BinaryObjectType, parent: XmlElement): XmlElement {
+  parent.addText(value)
+  parent.setAttr('mimeCode', mimeCode)
+  parent.setAttr('filename', filename)
   return parent
 }
 
@@ -135,29 +139,29 @@ function convertExchangedDocumentContext(
     businessProcessSpecifiedDocumentContextParameter,
     guidelineSpecifiedDocumentContextParameter,
   }: ExchangedDocumentContextType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  const context = parent.node('rsm:ExchangedDocumentContext')
+  const context = parent.addElement('rsm:ExchangedDocumentContext')
 
   if (testIndicator) {
-    convertIndicator(testIndicator, context.node('ram:TestIndicator'))
+    convertIndicator(testIndicator, context.addElement('ram:TestIndicator'))
   }
 
   if (businessProcessSpecifiedDocumentContextParameter) {
     convertDocumentContextParameter(
       businessProcessSpecifiedDocumentContextParameter,
-      context.node('ram:BusinessProcessSpecifiedDocumentContextParameter'),
+      context.addElement('ram:BusinessProcessSpecifiedDocumentContextParameter'),
     )
   }
 
   convertDocumentContextParameter(
     guidelineSpecifiedDocumentContextParameter,
-    context.node('ram:GuidelineSpecifiedDocumentContextParameter'),
+    context.addElement('ram:GuidelineSpecifiedDocumentContextParameter'),
   )
 }
 
-function convertDocumentContextParameter({ id }: ram.DocumentContextParameterType, parent: XMLElement): void {
-  convertID(id, parent.node('ram:ID'))
+function convertDocumentContextParameter({ id }: ram.DocumentContextParameterType, parent: XmlElement): void {
+  convertID(id, parent.addElement('ram:ID'))
 }
 
 // ---------------------------------------------------------------------------
@@ -166,64 +170,64 @@ function convertDocumentContextParameter({ id }: ram.DocumentContextParameterTyp
 
 function convertExchangedDocument(
   { id, name, typeCode, issueDateTime, copyIndicator, languageID, includedNote, effectiveSpecifiedPeriod }: ExchangedDocumentType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  const doc = parent.node('rsm:ExchangedDocument')
+  const doc = parent.addElement('rsm:ExchangedDocument')
 
-  convertID(id, doc.node('ram:ID'))
+  convertID(id, doc.addElement('ram:ID'))
 
   if (name) {
-    convertText(name, doc.node('ram:Name'))
+    convertText(name, doc.addElement('ram:Name'))
   }
 
-  doc.node('ram:TypeCode', typeCode.value)
+  doc.addElement('ram:TypeCode').addText(typeCode.value)
 
-  convertDateTime(issueDateTime, doc.node('ram:IssueDateTime'))
+  convertDateTime(issueDateTime, doc.addElement('ram:IssueDateTime'))
 
   if (copyIndicator) {
-    convertIndicator(copyIndicator, doc.node('ram:CopyIndicator'))
+    convertIndicator(copyIndicator, doc.addElement('ram:CopyIndicator'))
   }
 
   if (languageID && languageID.length > 0) {
-    languageID.forEach(lang => convertID(lang, doc.node('ram:LanguageID')))
+    languageID.forEach(lang => convertID(lang, doc.addElement('ram:LanguageID')))
   }
 
   if (includedNote && includedNote.length > 0) {
-    includedNote.forEach(note => convertNote(note, doc.node('ram:IncludedNote')))
+    includedNote.forEach(note => convertNote(note, doc.addElement('ram:IncludedNote')))
   }
 
   if (effectiveSpecifiedPeriod) {
-    convertSpecifiedPeriod(effectiveSpecifiedPeriod, doc.node('ram:EffectiveSpecifiedPeriod'))
+    convertSpecifiedPeriod(effectiveSpecifiedPeriod, doc.addElement('ram:EffectiveSpecifiedPeriod'))
   }
 }
 
-function convertNote({ contentCode, content, subjectCode }: ram.NoteType, parent: XMLElement): void {
+function convertNote({ contentCode, content, subjectCode }: ram.NoteType, parent: XmlElement): void {
   if (contentCode) {
-    convertCode(contentCode, parent.node('ram:ContentCode'))
+    convertCode(contentCode, parent.addElement('ram:ContentCode'))
   }
   if (content) {
-    convertText(content, parent.node('ram:Content'))
+    convertText(content, parent.addElement('ram:Content'))
   }
   if (subjectCode) {
-    convertCode(subjectCode, parent.node('ram:SubjectCode'))
+    convertCode(subjectCode, parent.addElement('ram:SubjectCode'))
   }
 }
 
 function convertSpecifiedPeriod(
   { description, startDateTime, endDateTime, completeDateTime }: ram.SpecifiedPeriodType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (startDateTime) {
-    convertDateTime(startDateTime, parent.node('ram:StartDateTime'))
+    convertDateTime(startDateTime, parent.addElement('ram:StartDateTime'))
   }
   if (endDateTime) {
-    convertDateTime(endDateTime, parent.node('ram:EndDateTime'))
+    convertDateTime(endDateTime, parent.addElement('ram:EndDateTime'))
   }
   if (completeDateTime) {
-    convertDateTime(completeDateTime, parent.node('ram:CompleteDateTime'))
+    convertDateTime(completeDateTime, parent.addElement('ram:CompleteDateTime'))
   }
 }
 
@@ -238,56 +242,56 @@ function convertSupplyChainTradeTransaction(
     applicableHeaderTradeDelivery,
     applicableHeaderTradeSettlement,
   }: SupplyChainTradeTransactionType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  const transaction = parent.node('rsm:SupplyChainTradeTransaction')
+  const transaction = parent.addElement('rsm:SupplyChainTradeTransaction')
 
   if (includedSupplyChainTradeLineItem && includedSupplyChainTradeLineItem.length > 0) {
     includedSupplyChainTradeLineItem.forEach((lineItem) => {
-      convertSupplyChainTradeLineItem(lineItem, transaction.node('ram:IncludedSupplyChainTradeLineItem'))
+      convertSupplyChainTradeLineItem(lineItem, transaction.addElement('ram:IncludedSupplyChainTradeLineItem'))
     })
   }
 
-  convertHeaderTradeAgreement(applicableHeaderTradeAgreement, transaction.node('ram:ApplicableHeaderTradeAgreement'))
-  convertHeaderTradeDelivery(applicableHeaderTradeDelivery, transaction.node('ram:ApplicableHeaderTradeDelivery'))
-  convertHeaderTradeSettlement(applicableHeaderTradeSettlement, transaction.node('ram:ApplicableHeaderTradeSettlement'))
+  convertHeaderTradeAgreement(applicableHeaderTradeAgreement, transaction.addElement('ram:ApplicableHeaderTradeAgreement'))
+  convertHeaderTradeDelivery(applicableHeaderTradeDelivery, transaction.addElement('ram:ApplicableHeaderTradeDelivery'))
+  convertHeaderTradeSettlement(applicableHeaderTradeSettlement, transaction.addElement('ram:ApplicableHeaderTradeSettlement'))
 }
 
 // ---------------------------------------------------------------------------
 // Line items
 // ---------------------------------------------------------------------------
 
-function convertSupplyChainTradeLineItem(lineItem: ram.SupplyChainTradeLineItemType, parent: XMLElement): void {
-  convertDocumentLineDocument(lineItem.associatedDocumentLineDocument, parent.node('ram:AssociatedDocumentLineDocument'))
-  convertTradeProduct(lineItem.specifiedTradeProduct, parent.node('ram:SpecifiedTradeProduct'))
+function convertSupplyChainTradeLineItem(lineItem: ram.SupplyChainTradeLineItemType, parent: XmlElement): void {
+  convertDocumentLineDocument(lineItem.associatedDocumentLineDocument, parent.addElement('ram:AssociatedDocumentLineDocument'))
+  convertTradeProduct(lineItem.specifiedTradeProduct, parent.addElement('ram:SpecifiedTradeProduct'))
 
   if (lineItem.specifiedLineTradeAgreement) {
-    convertLineTradeAgreement(lineItem.specifiedLineTradeAgreement, parent.node('ram:SpecifiedLineTradeAgreement'))
+    convertLineTradeAgreement(lineItem.specifiedLineTradeAgreement, parent.addElement('ram:SpecifiedLineTradeAgreement'))
   }
   if (lineItem.specifiedLineTradeDelivery) {
-    convertLineTradeDelivery(lineItem.specifiedLineTradeDelivery, parent.node('ram:SpecifiedLineTradeDelivery'))
+    convertLineTradeDelivery(lineItem.specifiedLineTradeDelivery, parent.addElement('ram:SpecifiedLineTradeDelivery'))
   }
   if (lineItem.specifiedLineTradeSettlement) {
-    convertLineTradeSettlement(lineItem.specifiedLineTradeSettlement, parent.node('ram:SpecifiedLineTradeSettlement'))
+    convertLineTradeSettlement(lineItem.specifiedLineTradeSettlement, parent.addElement('ram:SpecifiedLineTradeSettlement'))
   }
 }
 
 function convertDocumentLineDocument(
   { lineID, parentLineID, lineStatusCode, lineStatusReasonCode, includedNote }: ram.DocumentLineDocumentType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  convertID(lineID, parent.node('ram:LineID'))
+  convertID(lineID, parent.addElement('ram:LineID'))
   if (parentLineID) {
-    convertID(parentLineID, parent.node('ram:ParentLineID'))
+    convertID(parentLineID, parent.addElement('ram:ParentLineID'))
   }
   if (lineStatusCode) {
-    parent.node('ram:LineStatusCode', lineStatusCode.value)
+    parent.addElement('ram:LineStatusCode', lineStatusCode.value)
   }
   if (lineStatusReasonCode) {
-    convertCode(lineStatusReasonCode, parent.node('ram:LineStatusReasonCode'))
+    convertCode(lineStatusReasonCode, parent.addElement('ram:LineStatusReasonCode'))
   }
   if (includedNote && includedNote.length > 0) {
-    includedNote.forEach(note => convertNote(note, parent.node('ram:IncludedNote')))
+    includedNote.forEach(note => convertNote(note, parent.addElement('ram:IncludedNote')))
   }
 }
 
@@ -311,128 +315,128 @@ function convertTradeProduct(
     manufacturerTradeParty,
     includedReferencedProduct,
   }: ram.TradeProductType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (id) {
-    convertID(id, parent.node('ram:ID'))
+    convertID(id, parent.addElement('ram:ID'))
   }
   if (globalID) {
-    convertID(globalID, parent.node('ram:GlobalID'))
+    convertID(globalID, parent.addElement('ram:GlobalID'))
   }
   if (sellerAssignedID) {
-    convertID(sellerAssignedID, parent.node('ram:SellerAssignedID'))
+    convertID(sellerAssignedID, parent.addElement('ram:SellerAssignedID'))
   }
   if (buyerAssignedID) {
-    convertID(buyerAssignedID, parent.node('ram:BuyerAssignedID'))
+    convertID(buyerAssignedID, parent.addElement('ram:BuyerAssignedID'))
   }
   if (industryAssignedID) {
-    convertID(industryAssignedID, parent.node('ram:IndustryAssignedID'))
+    convertID(industryAssignedID, parent.addElement('ram:IndustryAssignedID'))
   }
   if (modelID) {
-    convertID(modelID, parent.node('ram:ModelID'))
+    convertID(modelID, parent.addElement('ram:ModelID'))
   }
   if (name) {
-    convertText(name, parent.node('ram:Name'))
+    convertText(name, parent.addElement('ram:Name'))
   }
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (batchID && batchID.length > 0) {
-    batchID.forEach(b => convertID(b, parent.node('ram:BatchID')))
+    batchID.forEach(b => convertID(b, parent.addElement('ram:BatchID')))
   }
   if (brandName) {
-    convertText(brandName, parent.node('ram:BrandName'))
+    convertText(brandName, parent.addElement('ram:BrandName'))
   }
   if (modelName) {
-    convertText(modelName, parent.node('ram:ModelName'))
+    convertText(modelName, parent.addElement('ram:ModelName'))
   }
   if (applicableProductCharacteristic && applicableProductCharacteristic.length > 0) {
-    applicableProductCharacteristic.forEach(c => convertProductCharacteristic(c, parent.node('ram:ApplicableProductCharacteristic')))
+    applicableProductCharacteristic.forEach(c => convertProductCharacteristic(c, parent.addElement('ram:ApplicableProductCharacteristic')))
   }
   if (designatedProductClassification && designatedProductClassification.length > 0) {
-    designatedProductClassification.forEach(c => convertProductClassification(c, parent.node('ram:DesignatedProductClassification')))
+    designatedProductClassification.forEach(c => convertProductClassification(c, parent.addElement('ram:DesignatedProductClassification')))
   }
   if (individualTradeProductInstance && individualTradeProductInstance.length > 0) {
-    individualTradeProductInstance.forEach(i => convertTradeProductInstance(i, parent.node('ram:IndividualTradeProductInstance')))
+    individualTradeProductInstance.forEach(i => convertTradeProductInstance(i, parent.addElement('ram:IndividualTradeProductInstance')))
   }
   if (originTradeCountry?.id) {
-    parent.node('ram:OriginTradeCountry').node('ram:ID', originTradeCountry.id.value)
+    parent.addElement('ram:OriginTradeCountry').addElement('ram:ID').addText(originTradeCountry.id.value)
   }
   if (manufacturerTradeParty) {
-    convertTradeParty(manufacturerTradeParty, parent.node('ram:ManufacturerTradeParty'))
+    convertTradeParty(manufacturerTradeParty, parent.addElement('ram:ManufacturerTradeParty'))
   }
   if (includedReferencedProduct && includedReferencedProduct.length > 0) {
-    includedReferencedProduct.forEach(p => convertReferencedProduct(p, parent.node('ram:IncludedReferencedProduct')))
+    includedReferencedProduct.forEach(p => convertReferencedProduct(p, parent.addElement('ram:IncludedReferencedProduct')))
   }
 }
 
 function convertProductCharacteristic(
   { typeCode, description, valueMeasure, value }: ram.ProductCharacteristicType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (typeCode) {
-    convertCode(typeCode, parent.node('ram:TypeCode'))
+    convertCode(typeCode, parent.addElement('ram:TypeCode'))
   }
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (valueMeasure) {
-    convertMeasure(valueMeasure, parent.node('ram:ValueMeasure'))
+    convertMeasure(valueMeasure, parent.addElement('ram:ValueMeasure'))
   }
   if (value) {
-    convertText(value, parent.node('ram:Value'))
+    convertText(value, parent.addElement('ram:Value'))
   }
 }
 
 function convertProductClassification(
   { classCode, className }: ram.ProductClassificationType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (classCode) {
-    convertCode(classCode, parent.node('ram:ClassCode'))
+    convertCode(classCode, parent.addElement('ram:ClassCode'))
   }
   if (className) {
-    convertText(className, parent.node('ram:ClassName'))
+    convertText(className, parent.addElement('ram:ClassName'))
   }
 }
 
 function convertTradeProductInstance(
   { batchID, supplierAssignedSerialID }: ram.TradeProductInstanceType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (batchID) {
-    convertID(batchID, parent.node('ram:BatchID'))
+    convertID(batchID, parent.addElement('ram:BatchID'))
   }
   if (supplierAssignedSerialID) {
-    convertID(supplierAssignedSerialID, parent.node('ram:SupplierAssignedSerialID'))
+    convertID(supplierAssignedSerialID, parent.addElement('ram:SupplierAssignedSerialID'))
   }
 }
 
 function convertReferencedProduct(
   { id, globalID, sellerAssignedID, buyerAssignedID, industryAssignedID, name, description, unitQuantity }: ram.ReferencedProductType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (id) {
-    convertID(id, parent.node('ram:ID'))
+    convertID(id, parent.addElement('ram:ID'))
   }
   if (globalID && globalID.length > 0) {
-    globalID.forEach(g => convertID(g, parent.node('ram:GlobalID')))
+    globalID.forEach(g => convertID(g, parent.addElement('ram:GlobalID')))
   }
   if (sellerAssignedID) {
-    convertID(sellerAssignedID, parent.node('ram:SellerAssignedID'))
+    convertID(sellerAssignedID, parent.addElement('ram:SellerAssignedID'))
   }
   if (buyerAssignedID) {
-    convertID(buyerAssignedID, parent.node('ram:BuyerAssignedID'))
+    convertID(buyerAssignedID, parent.addElement('ram:BuyerAssignedID'))
   }
   if (industryAssignedID) {
-    convertID(industryAssignedID, parent.node('ram:IndustryAssignedID'))
+    convertID(industryAssignedID, parent.addElement('ram:IndustryAssignedID'))
   }
-  convertText(name, parent.node('ram:Name'))
+  convertText(name, parent.addElement('ram:Name'))
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (unitQuantity) {
-    convertQuantity(unitQuantity, parent.node('ram:UnitQuantity'))
+    convertQuantity(unitQuantity, parent.addElement('ram:UnitQuantity'))
   }
 }
 
@@ -449,55 +453,55 @@ function convertLineTradeAgreement(
     itemSellerTradeParty,
     ultimateCustomerOrderReferencedDocument,
   }: ram.LineTradeAgreementType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (applicableTradeDeliveryTerms) {
-    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.node('ram:ApplicableTradeDeliveryTerms'))
+    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.addElement('ram:ApplicableTradeDeliveryTerms'))
   }
   if (sellerOrderReferencedDocument) {
-    convertReferencedDocument(sellerOrderReferencedDocument, parent.node('ram:SellerOrderReferencedDocument'))
+    convertReferencedDocument(sellerOrderReferencedDocument, parent.addElement('ram:SellerOrderReferencedDocument'))
   }
   if (buyerOrderReferencedDocument) {
-    convertReferencedDocument(buyerOrderReferencedDocument, parent.node('ram:BuyerOrderReferencedDocument'))
+    convertReferencedDocument(buyerOrderReferencedDocument, parent.addElement('ram:BuyerOrderReferencedDocument'))
   }
   if (quotationReferencedDocument) {
-    convertReferencedDocument(quotationReferencedDocument, parent.node('ram:QuotationReferencedDocument'))
+    convertReferencedDocument(quotationReferencedDocument, parent.addElement('ram:QuotationReferencedDocument'))
   }
   if (contractReferencedDocument) {
-    convertReferencedDocument(contractReferencedDocument, parent.node('ram:ContractReferencedDocument'))
+    convertReferencedDocument(contractReferencedDocument, parent.addElement('ram:ContractReferencedDocument'))
   }
   if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
-    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:AdditionalReferencedDocument')))
   }
   if (grossPriceProductTradePrice) {
-    convertTradePrice(grossPriceProductTradePrice, parent.node('ram:GrossPriceProductTradePrice'))
+    convertTradePrice(grossPriceProductTradePrice, parent.addElement('ram:GrossPriceProductTradePrice'))
   }
   if (netPriceProductTradePrice) {
-    convertTradePrice(netPriceProductTradePrice, parent.node('ram:NetPriceProductTradePrice'))
+    convertTradePrice(netPriceProductTradePrice, parent.addElement('ram:NetPriceProductTradePrice'))
   }
   if (itemSellerTradeParty) {
-    convertTradeParty(itemSellerTradeParty, parent.node('ram:ItemSellerTradeParty'))
+    convertTradeParty(itemSellerTradeParty, parent.addElement('ram:ItemSellerTradeParty'))
   }
   if (ultimateCustomerOrderReferencedDocument && ultimateCustomerOrderReferencedDocument.length > 0) {
-    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:UltimateCustomerOrderReferencedDocument')))
+    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:UltimateCustomerOrderReferencedDocument')))
   }
 }
 
 function convertTradePrice(
   { chargeAmount, basisQuantity, appliedTradeAllowanceCharge, includedTradeTax }: ram.TradePriceType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (chargeAmount) {
-    convertAmount(chargeAmount, parent.node('ram:ChargeAmount'))
+    convertAmount(chargeAmount, parent.addElement('ram:ChargeAmount'))
   }
   if (basisQuantity) {
-    convertQuantity(basisQuantity, parent.node('ram:BasisQuantity'))
+    convertQuantity(basisQuantity, parent.addElement('ram:BasisQuantity'))
   }
   if (appliedTradeAllowanceCharge && appliedTradeAllowanceCharge.length > 0) {
-    appliedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:AppliedTradeAllowanceCharge')))
+    appliedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.addElement('ram:AppliedTradeAllowanceCharge')))
   }
   if (includedTradeTax) {
-    convertTradeTax(includedTradeTax, parent.node('ram:IncludedTradeTax'))
+    convertTradeTax(includedTradeTax, parent.addElement('ram:IncludedTradeTax'))
   }
 }
 
@@ -514,37 +518,37 @@ function convertLineTradeDelivery(
     receivingAdviceReferencedDocument,
     deliveryNoteReferencedDocument,
   }: ram.LineTradeDeliveryType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (billedQuantity) {
-    convertQuantity(billedQuantity, parent.node('ram:BilledQuantity'))
+    convertQuantity(billedQuantity, parent.addElement('ram:BilledQuantity'))
   }
   if (chargeFreeQuantity) {
-    convertQuantity(chargeFreeQuantity, parent.node('ram:ChargeFreeQuantity'))
+    convertQuantity(chargeFreeQuantity, parent.addElement('ram:ChargeFreeQuantity'))
   }
   if (packageQuantity) {
-    convertQuantity(packageQuantity, parent.node('ram:PackageQuantity'))
+    convertQuantity(packageQuantity, parent.addElement('ram:PackageQuantity'))
   }
   if (perPackageUnitQuantity) {
-    convertQuantity(perPackageUnitQuantity, parent.node('ram:PerPackageUnitQuantity'))
+    convertQuantity(perPackageUnitQuantity, parent.addElement('ram:PerPackageUnitQuantity'))
   }
   if (shipToTradeParty) {
-    convertTradeParty(shipToTradeParty, parent.node('ram:ShipToTradeParty'))
+    convertTradeParty(shipToTradeParty, parent.addElement('ram:ShipToTradeParty'))
   }
   if (ultimateShipToTradeParty) {
-    convertTradeParty(ultimateShipToTradeParty, parent.node('ram:UltimateShipToTradeParty'))
+    convertTradeParty(ultimateShipToTradeParty, parent.addElement('ram:UltimateShipToTradeParty'))
   }
   if (actualDeliverySupplyChainEvent) {
-    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.node('ram:ActualDeliverySupplyChainEvent'))
+    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.addElement('ram:ActualDeliverySupplyChainEvent'))
   }
   if (despatchAdviceReferencedDocument) {
-    convertReferencedDocument(despatchAdviceReferencedDocument, parent.node('ram:DespatchAdviceReferencedDocument'))
+    convertReferencedDocument(despatchAdviceReferencedDocument, parent.addElement('ram:DespatchAdviceReferencedDocument'))
   }
   if (receivingAdviceReferencedDocument) {
-    convertReferencedDocument(receivingAdviceReferencedDocument, parent.node('ram:ReceivingAdviceReferencedDocument'))
+    convertReferencedDocument(receivingAdviceReferencedDocument, parent.addElement('ram:ReceivingAdviceReferencedDocument'))
   }
   if (deliveryNoteReferencedDocument) {
-    convertReferencedDocument(deliveryNoteReferencedDocument, parent.node('ram:DeliveryNoteReferencedDocument'))
+    convertReferencedDocument(deliveryNoteReferencedDocument, parent.addElement('ram:DeliveryNoteReferencedDocument'))
   }
 }
 
@@ -558,55 +562,55 @@ function convertLineTradeSettlement(
     additionalReferencedDocument,
     receivableSpecifiedTradeAccountingAccount,
   }: ram.LineTradeSettlementType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (applicableTradeTax && applicableTradeTax.length > 0) {
-    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.node('ram:ApplicableTradeTax')))
+    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.addElement('ram:ApplicableTradeTax')))
   }
   if (billingSpecifiedPeriod) {
-    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.node('ram:BillingSpecifiedPeriod'))
+    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.addElement('ram:BillingSpecifiedPeriod'))
   }
   if (specifiedTradeAllowanceCharge && specifiedTradeAllowanceCharge.length > 0) {
-    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:SpecifiedTradeAllowanceCharge')))
+    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.addElement('ram:SpecifiedTradeAllowanceCharge')))
   }
   if (specifiedTradeSettlementLineMonetarySummation) {
     convertTradeSettlementLineMonetarySummation(
       specifiedTradeSettlementLineMonetarySummation,
-      parent.node('ram:SpecifiedTradeSettlementLineMonetarySummation'),
+      parent.addElement('ram:SpecifiedTradeSettlementLineMonetarySummation'),
     )
   }
   if (invoiceReferencedDocument) {
-    convertReferencedDocument(invoiceReferencedDocument, parent.node('ram:InvoiceReferencedDocument'))
+    convertReferencedDocument(invoiceReferencedDocument, parent.addElement('ram:InvoiceReferencedDocument'))
   }
   if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
-    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:AdditionalReferencedDocument')))
   }
   if (receivableSpecifiedTradeAccountingAccount && receivableSpecifiedTradeAccountingAccount.length > 0) {
-    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.node('ram:ReceivableSpecifiedTradeAccountingAccount')))
+    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.addElement('ram:ReceivableSpecifiedTradeAccountingAccount')))
   }
 }
 
 function convertTradeSettlementLineMonetarySummation(
   { lineTotalAmount, chargeTotalAmount, allowanceTotalAmount, taxTotalAmount, grandTotalAmount, totalAllowanceChargeAmount }: ram.TradeSettlementLineMonetarySummationType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (lineTotalAmount) {
-    convertAmount(lineTotalAmount, parent.node('ram:LineTotalAmount'))
+    convertAmount(lineTotalAmount, parent.addElement('ram:LineTotalAmount'))
   }
   if (chargeTotalAmount) {
-    convertAmount(chargeTotalAmount, parent.node('ram:ChargeTotalAmount'))
+    convertAmount(chargeTotalAmount, parent.addElement('ram:ChargeTotalAmount'))
   }
   if (allowanceTotalAmount) {
-    convertAmount(allowanceTotalAmount, parent.node('ram:AllowanceTotalAmount'))
+    convertAmount(allowanceTotalAmount, parent.addElement('ram:AllowanceTotalAmount'))
   }
   if (taxTotalAmount) {
-    convertAmount(taxTotalAmount, parent.node('ram:TaxTotalAmount'))
+    convertAmount(taxTotalAmount, parent.addElement('ram:TaxTotalAmount'))
   }
   if (grandTotalAmount) {
-    convertAmount(grandTotalAmount, parent.node('ram:GrandTotalAmount'))
+    convertAmount(grandTotalAmount, parent.addElement('ram:GrandTotalAmount'))
   }
   if (totalAllowanceChargeAmount) {
-    convertAmount(totalAllowanceChargeAmount, parent.node('ram:TotalAllowanceChargeAmount'))
+    convertAmount(totalAllowanceChargeAmount, parent.addElement('ram:TotalAllowanceChargeAmount'))
   }
 }
 
@@ -633,72 +637,72 @@ function convertHeaderTradeAgreement(
     specifiedProcuringProject,
     ultimateCustomerOrderReferencedDocument,
   }: HeaderTradeAgreementType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (buyerReference) {
-    convertText(buyerReference, parent.node('ram:BuyerReference'))
+    convertText(buyerReference, parent.addElement('ram:BuyerReference'))
   }
 
-  convertTradeParty(sellerTradeParty, parent.node('ram:SellerTradeParty'))
-  convertTradeParty(buyerTradeParty, parent.node('ram:BuyerTradeParty'))
+  convertTradeParty(sellerTradeParty, parent.addElement('ram:SellerTradeParty'))
+  convertTradeParty(buyerTradeParty, parent.addElement('ram:BuyerTradeParty'))
 
   if (salesAgentTradeParty) {
-    convertTradeParty(salesAgentTradeParty, parent.node('ram:SalesAgentTradeParty'))
+    convertTradeParty(salesAgentTradeParty, parent.addElement('ram:SalesAgentTradeParty'))
   }
   if (buyerTaxRepresentativeTradeParty) {
-    convertTradeParty(buyerTaxRepresentativeTradeParty, parent.node('ram:BuyerTaxRepresentativeTradeParty'))
+    convertTradeParty(buyerTaxRepresentativeTradeParty, parent.addElement('ram:BuyerTaxRepresentativeTradeParty'))
   }
   if (sellerTaxRepresentativeTradeParty) {
-    convertTradeParty(sellerTaxRepresentativeTradeParty, parent.node('ram:SellerTaxRepresentativeTradeParty'))
+    convertTradeParty(sellerTaxRepresentativeTradeParty, parent.addElement('ram:SellerTaxRepresentativeTradeParty'))
   }
   if (productEndUserTradeParty) {
-    convertTradeParty(productEndUserTradeParty, parent.node('ram:ProductEndUserTradeParty'))
+    convertTradeParty(productEndUserTradeParty, parent.addElement('ram:ProductEndUserTradeParty'))
   }
   if (applicableTradeDeliveryTerms) {
-    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.node('ram:ApplicableTradeDeliveryTerms'))
+    convertTradeDeliveryTerms(applicableTradeDeliveryTerms, parent.addElement('ram:ApplicableTradeDeliveryTerms'))
   }
   if (sellerOrderReferencedDocument) {
-    convertReferencedDocument(sellerOrderReferencedDocument, parent.node('ram:SellerOrderReferencedDocument'))
+    convertReferencedDocument(sellerOrderReferencedDocument, parent.addElement('ram:SellerOrderReferencedDocument'))
   }
   if (buyerOrderReferencedDocument) {
-    convertReferencedDocument(buyerOrderReferencedDocument, parent.node('ram:BuyerOrderReferencedDocument'))
+    convertReferencedDocument(buyerOrderReferencedDocument, parent.addElement('ram:BuyerOrderReferencedDocument'))
   }
   if (quotationReferencedDocument) {
-    convertReferencedDocument(quotationReferencedDocument, parent.node('ram:QuotationReferencedDocument'))
+    convertReferencedDocument(quotationReferencedDocument, parent.addElement('ram:QuotationReferencedDocument'))
   }
   if (contractReferencedDocument) {
-    convertReferencedDocument(contractReferencedDocument, parent.node('ram:ContractReferencedDocument'))
+    convertReferencedDocument(contractReferencedDocument, parent.addElement('ram:ContractReferencedDocument'))
   }
   if (additionalReferencedDocument && additionalReferencedDocument.length > 0) {
-    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:AdditionalReferencedDocument')))
+    additionalReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:AdditionalReferencedDocument')))
   }
   if (buyerAgentTradeParty) {
-    convertTradeParty(buyerAgentTradeParty, parent.node('ram:BuyerAgentTradeParty'))
+    convertTradeParty(buyerAgentTradeParty, parent.addElement('ram:BuyerAgentTradeParty'))
   }
   if (specifiedProcuringProject) {
-    convertProcuringProject(specifiedProcuringProject, parent.node('ram:SpecifiedProcuringProject'))
+    convertProcuringProject(specifiedProcuringProject, parent.addElement('ram:SpecifiedProcuringProject'))
   }
   if (ultimateCustomerOrderReferencedDocument && ultimateCustomerOrderReferencedDocument.length > 0) {
-    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:UltimateCustomerOrderReferencedDocument')))
+    ultimateCustomerOrderReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:UltimateCustomerOrderReferencedDocument')))
   }
 }
 
-function convertProcuringProject({ id, name }: ram.ProcuringProjectType, parent: XMLElement): void {
-  convertID(id, parent.node('ram:ID'))
-  convertText(name, parent.node('ram:Name'))
+function convertProcuringProject({ id, name }: ram.ProcuringProjectType, parent: XmlElement): void {
+  convertID(id, parent.addElement('ram:ID'))
+  convertText(name, parent.addElement('ram:Name'))
 }
 
-function convertTradeDeliveryTerms({ deliveryTypeCode, relevantTradeLocation }: ram.TradeDeliveryTermsType, parent: XMLElement): void {
+function convertTradeDeliveryTerms({ deliveryTypeCode, relevantTradeLocation }: ram.TradeDeliveryTermsType, parent: XmlElement): void {
   if (deliveryTypeCode) {
-    parent.node('ram:DeliveryTypeCode', deliveryTypeCode.value)
+    parent.addElement('ram:DeliveryTypeCode').addText(deliveryTypeCode.value)
   }
   if (relevantTradeLocation) {
-    const el = parent.node('ram:RelevantTradeLocation')
+    const el = parent.addElement('ram:RelevantTradeLocation')
     if (relevantTradeLocation.countryID) {
-      el.node('ram:CountryID', relevantTradeLocation.countryID.value)
+      el.addElement('ram:CountryID').addText(relevantTradeLocation.countryID.value)
     }
     if (relevantTradeLocation.name) {
-      convertText(relevantTradeLocation.name, el.node('ram:Name'))
+      convertText(relevantTradeLocation.name, el.addElement('ram:Name'))
     }
   }
 }
@@ -720,113 +724,113 @@ function convertTradeParty(
     uriUniversalCommunication,
     specifiedTaxRegistration,
   }: ram.TradePartyType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (id && id.length > 0) {
-    id.forEach(i => convertID(i, parent.node('ram:ID')))
+    id.forEach(i => convertID(i, parent.addElement('ram:ID')))
   }
   if (globalID && globalID.length > 0) {
-    globalID.forEach(g => convertID(g, parent.node('ram:GlobalID')))
+    globalID.forEach(g => convertID(g, parent.addElement('ram:GlobalID')))
   }
   if (name) {
-    convertText(name, parent.node('ram:Name'))
+    convertText(name, parent.addElement('ram:Name'))
   }
   if (roleCode) {
-    parent.node('ram:RoleCode', roleCode.value)
+    parent.addElement('ram:RoleCode', roleCode.value)
   }
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (specifiedLegalOrganization) {
-    convertLegalOrganization(specifiedLegalOrganization, parent.node('ram:SpecifiedLegalOrganization'))
+    convertLegalOrganization(specifiedLegalOrganization, parent.addElement('ram:SpecifiedLegalOrganization'))
   }
   if (definedTradeContact && definedTradeContact.length > 0) {
-    definedTradeContact.forEach(c => convertTradeContact(c, parent.node('ram:DefinedTradeContact')))
+    definedTradeContact.forEach(c => convertTradeContact(c, parent.addElement('ram:DefinedTradeContact')))
   }
   if (postalTradeAddress) {
-    convertTradeAddress(postalTradeAddress, parent.node('ram:PostalTradeAddress'))
+    convertTradeAddress(postalTradeAddress, parent.addElement('ram:PostalTradeAddress'))
   }
   if (uriUniversalCommunication) {
-    convertUniversalCommunication(uriUniversalCommunication, parent.node('ram:URIUniversalCommunication'))
+    convertUniversalCommunication(uriUniversalCommunication, parent.addElement('ram:URIUniversalCommunication'))
   }
   if (specifiedTaxRegistration && specifiedTaxRegistration.length > 0) {
     specifiedTaxRegistration.forEach((tax) => {
-      const taxEl = parent.node('ram:SpecifiedTaxRegistration')
-      convertID(tax.id, taxEl.node('ram:ID'))
+      const taxEl = parent.addElement('ram:SpecifiedTaxRegistration')
+      convertID(tax.id, taxEl.addElement('ram:ID'))
     })
   }
 }
 
 function convertLegalOrganization(
   { id, tradingBusinessName, postalTradeAddress }: ram.LegalOrganizationType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (id) {
-    convertID(id, parent.node('ram:ID'))
+    convertID(id, parent.addElement('ram:ID'))
   }
   if (tradingBusinessName) {
-    convertText(tradingBusinessName, parent.node('ram:TradingBusinessName'))
+    convertText(tradingBusinessName, parent.addElement('ram:TradingBusinessName'))
   }
   if (postalTradeAddress) {
-    convertTradeAddress(postalTradeAddress, parent.node('ram:PostalTradeAddress'))
+    convertTradeAddress(postalTradeAddress, parent.addElement('ram:PostalTradeAddress'))
   }
 }
 
 function convertTradeContact(
   { personName, departmentName, typeCode, telephoneUniversalCommunication, faxUniversalCommunication, emailURIUniversalCommunication }: ram.TradeContactType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (personName) {
-    convertText(personName, parent.node('ram:PersonName'))
+    convertText(personName, parent.addElement('ram:PersonName'))
   }
   if (departmentName) {
-    convertText(departmentName, parent.node('ram:DepartmentName'))
+    convertText(departmentName, parent.addElement('ram:DepartmentName'))
   }
   if (typeCode) {
-    parent.node('ram:TypeCode', typeCode.value)
+    parent.addElement('ram:TypeCode', typeCode.value)
   }
   if (telephoneUniversalCommunication) {
-    convertUniversalCommunication(telephoneUniversalCommunication, parent.node('ram:TelephoneUniversalCommunication'))
+    convertUniversalCommunication(telephoneUniversalCommunication, parent.addElement('ram:TelephoneUniversalCommunication'))
   }
   if (faxUniversalCommunication) {
-    convertUniversalCommunication(faxUniversalCommunication, parent.node('ram:FaxUniversalCommunication'))
+    convertUniversalCommunication(faxUniversalCommunication, parent.addElement('ram:FaxUniversalCommunication'))
   }
   if (emailURIUniversalCommunication) {
-    convertUniversalCommunication(emailURIUniversalCommunication, parent.node('ram:EmailURIUniversalCommunication'))
+    convertUniversalCommunication(emailURIUniversalCommunication, parent.addElement('ram:EmailURIUniversalCommunication'))
   }
 }
 
-function convertUniversalCommunication({ uriID, completeNumber }: ram.UniversalCommunicationType, parent: XMLElement): void {
+function convertUniversalCommunication({ uriID, completeNumber }: ram.UniversalCommunicationType, parent: XmlElement): void {
   if (uriID) {
-    convertID(uriID, parent.node('ram:URIID'))
+    convertID(uriID, parent.addElement('ram:URIID'))
   }
   if (completeNumber) {
-    convertText(completeNumber, parent.node('ram:CompleteNumber'))
+    convertText(completeNumber, parent.addElement('ram:CompleteNumber'))
   }
 }
 
 function convertTradeAddress(
   { postcodeCode, lineOne, lineTwo, lineThree, cityName, countryID, countrySubDivisionName }: ram.TradeAddressType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (postcodeCode) {
-    convertCode(postcodeCode, parent.node('ram:PostcodeCode'))
+    convertCode(postcodeCode, parent.addElement('ram:PostcodeCode'))
   }
   if (lineOne) {
-    convertText(lineOne, parent.node('ram:LineOne'))
+    convertText(lineOne, parent.addElement('ram:LineOne'))
   }
   if (lineTwo) {
-    convertText(lineTwo, parent.node('ram:LineTwo'))
+    convertText(lineTwo, parent.addElement('ram:LineTwo'))
   }
   if (lineThree) {
-    convertText(lineThree, parent.node('ram:LineThree'))
+    convertText(lineThree, parent.addElement('ram:LineThree'))
   }
   if (cityName) {
-    convertText(cityName, parent.node('ram:CityName'))
+    convertText(cityName, parent.addElement('ram:CityName'))
   }
-  parent.node('ram:CountryID', countryID.value)
+  parent.addElement('ram:CountryID').addText(countryID.value)
   if (countrySubDivisionName && countrySubDivisionName.length > 0) {
-    countrySubDivisionName.forEach(n => convertText(n, parent.node('ram:CountrySubDivisionName')))
+    countrySubDivisionName.forEach(n => convertText(n, parent.addElement('ram:CountrySubDivisionName')))
   }
 }
 
@@ -845,45 +849,45 @@ function convertHeaderTradeDelivery(
     receivingAdviceReferencedDocument,
     deliveryNoteReferencedDocument,
   }: HeaderTradeDeliveryType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (relatedSupplyChainConsignment) {
-    convertSupplyChainConsignment(relatedSupplyChainConsignment, parent.node('ram:RelatedSupplyChainConsignment'))
+    convertSupplyChainConsignment(relatedSupplyChainConsignment, parent.addElement('ram:RelatedSupplyChainConsignment'))
   }
   if (shipToTradeParty) {
-    convertTradeParty(shipToTradeParty, parent.node('ram:ShipToTradeParty'))
+    convertTradeParty(shipToTradeParty, parent.addElement('ram:ShipToTradeParty'))
   }
   if (ultimateShipToTradeParty) {
-    convertTradeParty(ultimateShipToTradeParty, parent.node('ram:UltimateShipToTradeParty'))
+    convertTradeParty(ultimateShipToTradeParty, parent.addElement('ram:UltimateShipToTradeParty'))
   }
   if (shipFromTradeParty) {
-    convertTradeParty(shipFromTradeParty, parent.node('ram:ShipFromTradeParty'))
+    convertTradeParty(shipFromTradeParty, parent.addElement('ram:ShipFromTradeParty'))
   }
   if (actualDeliverySupplyChainEvent) {
-    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.node('ram:ActualDeliverySupplyChainEvent'))
+    convertSupplyChainEvent(actualDeliverySupplyChainEvent, parent.addElement('ram:ActualDeliverySupplyChainEvent'))
   }
   if (despatchAdviceReferencedDocument) {
-    convertReferencedDocument(despatchAdviceReferencedDocument, parent.node('ram:DespatchAdviceReferencedDocument'))
+    convertReferencedDocument(despatchAdviceReferencedDocument, parent.addElement('ram:DespatchAdviceReferencedDocument'))
   }
   if (receivingAdviceReferencedDocument) {
-    convertReferencedDocument(receivingAdviceReferencedDocument, parent.node('ram:ReceivingAdviceReferencedDocument'))
+    convertReferencedDocument(receivingAdviceReferencedDocument, parent.addElement('ram:ReceivingAdviceReferencedDocument'))
   }
   if (deliveryNoteReferencedDocument) {
-    convertReferencedDocument(deliveryNoteReferencedDocument, parent.node('ram:DeliveryNoteReferencedDocument'))
+    convertReferencedDocument(deliveryNoteReferencedDocument, parent.addElement('ram:DeliveryNoteReferencedDocument'))
   }
 }
 
-function convertSupplyChainConsignment({ specifiedLogisticsTransportMovement }: ram.SupplyChainConsignmentType, parent: XMLElement): void {
+function convertSupplyChainConsignment({ specifiedLogisticsTransportMovement }: ram.SupplyChainConsignmentType, parent: XmlElement): void {
   if (specifiedLogisticsTransportMovement && specifiedLogisticsTransportMovement.length > 0) {
     specifiedLogisticsTransportMovement.forEach((m) => {
-      parent.node('ram:SpecifiedLogisticsTransportMovement').node('ram:ModeCode', m.modeCode.value)
+      parent.addElement('ram:SpecifiedLogisticsTransportMovement').addElement('ram:ModeCode').addText(m.modeCode.value)
     })
   }
 }
 
-function convertSupplyChainEvent({ occurrenceDateTime }: ram.SupplyChainEventType, parent: XMLElement): void {
+function convertSupplyChainEvent({ occurrenceDateTime }: ram.SupplyChainEventType, parent: XmlElement): void {
   if (occurrenceDateTime) {
-    convertDateTime(occurrenceDateTime, parent.node('ram:OccurrenceDateTime'))
+    convertDateTime(occurrenceDateTime, parent.addElement('ram:OccurrenceDateTime'))
   }
 }
 
@@ -915,95 +919,95 @@ function convertHeaderTradeSettlement(
     receivableSpecifiedTradeAccountingAccount,
     specifiedAdvancePayment,
   }: HeaderTradeSettlementType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (creditorReferenceID) {
-    convertID(creditorReferenceID, parent.node('ram:CreditorReferenceID'))
+    convertID(creditorReferenceID, parent.addElement('ram:CreditorReferenceID'))
   }
   if (paymentReference) {
-    convertText(paymentReference, parent.node('ram:PaymentReference'))
+    convertText(paymentReference, parent.addElement('ram:PaymentReference'))
   }
   if (taxCurrencyCode) {
-    parent.node('ram:TaxCurrencyCode', taxCurrencyCode.value)
+    parent.addElement('ram:TaxCurrencyCode').addText(taxCurrencyCode.value)
   }
 
-  parent.node('ram:InvoiceCurrencyCode', invoiceCurrencyCode.value)
+  parent.addElement('ram:InvoiceCurrencyCode').addText(invoiceCurrencyCode.value)
 
   // The following are EXTENDED-only header parties
   if (invoiceIssuerReference) {
-    convertText(invoiceIssuerReference, parent.node('ram:InvoiceIssuerReference'))
+    convertText(invoiceIssuerReference, parent.addElement('ram:InvoiceIssuerReference'))
   }
   if (invoicerTradeParty) {
-    convertTradeParty(invoicerTradeParty, parent.node('ram:InvoicerTradeParty'))
+    convertTradeParty(invoicerTradeParty, parent.addElement('ram:InvoicerTradeParty'))
   }
   if (invoiceeTradeParty) {
-    convertTradeParty(invoiceeTradeParty, parent.node('ram:InvoiceeTradeParty'))
+    convertTradeParty(invoiceeTradeParty, parent.addElement('ram:InvoiceeTradeParty'))
   }
   if (payeeTradeParty) {
-    convertTradeParty(payeeTradeParty, parent.node('ram:PayeeTradeParty'))
+    convertTradeParty(payeeTradeParty, parent.addElement('ram:PayeeTradeParty'))
   }
   if (payerTradeParty) {
-    convertTradeParty(payerTradeParty, parent.node('ram:PayerTradeParty'))
+    convertTradeParty(payerTradeParty, parent.addElement('ram:PayerTradeParty'))
   }
   if (taxApplicableTradeCurrencyExchange) {
-    convertTradeCurrencyExchange(taxApplicableTradeCurrencyExchange, parent.node('ram:TaxApplicableTradeCurrencyExchange'))
+    convertTradeCurrencyExchange(taxApplicableTradeCurrencyExchange, parent.addElement('ram:TaxApplicableTradeCurrencyExchange'))
   }
 
   if (specifiedTradeSettlementPaymentMeans && specifiedTradeSettlementPaymentMeans.length > 0) {
-    specifiedTradeSettlementPaymentMeans.forEach(pm => convertPaymentMeans(pm, parent.node('ram:SpecifiedTradeSettlementPaymentMeans')))
+    specifiedTradeSettlementPaymentMeans.forEach(pm => convertPaymentMeans(pm, parent.addElement('ram:SpecifiedTradeSettlementPaymentMeans')))
   }
 
   if (applicableTradeTax && applicableTradeTax.length > 0) {
-    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.node('ram:ApplicableTradeTax')))
+    applicableTradeTax.forEach(tax => convertTradeTax(tax, parent.addElement('ram:ApplicableTradeTax')))
   }
 
   if (billingSpecifiedPeriod) {
-    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.node('ram:BillingSpecifiedPeriod'))
+    convertSpecifiedPeriod(billingSpecifiedPeriod, parent.addElement('ram:BillingSpecifiedPeriod'))
   }
 
   if (specifiedTradeAllowanceCharge && specifiedTradeAllowanceCharge.length > 0) {
-    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.node('ram:SpecifiedTradeAllowanceCharge')))
+    specifiedTradeAllowanceCharge.forEach(ac => convertAllowanceCharge(ac, parent.addElement('ram:SpecifiedTradeAllowanceCharge')))
   }
 
   if (specifiedLogisticsServiceCharge && specifiedLogisticsServiceCharge.length > 0) {
-    specifiedLogisticsServiceCharge.forEach(c => convertLogisticsServiceCharge(c, parent.node('ram:SpecifiedLogisticsServiceCharge')))
+    specifiedLogisticsServiceCharge.forEach(c => convertLogisticsServiceCharge(c, parent.addElement('ram:SpecifiedLogisticsServiceCharge')))
   }
 
   if (specifiedTradePaymentTerms && specifiedTradePaymentTerms.length > 0) {
-    specifiedTradePaymentTerms.forEach(t => convertPaymentTerms(t, parent.node('ram:SpecifiedTradePaymentTerms')))
+    specifiedTradePaymentTerms.forEach(t => convertPaymentTerms(t, parent.addElement('ram:SpecifiedTradePaymentTerms')))
   }
 
   convertTradeSettlementHeaderMonetarySummation(
     specifiedTradeSettlementHeaderMonetarySummation,
-    parent.node('ram:SpecifiedTradeSettlementHeaderMonetarySummation'),
+    parent.addElement('ram:SpecifiedTradeSettlementHeaderMonetarySummation'),
   )
 
   if (specifiedFinancialAdjustment && specifiedFinancialAdjustment.length > 0) {
-    specifiedFinancialAdjustment.forEach(a => convertFinancialAdjustment(a, parent.node('ram:SpecifiedFinancialAdjustment')))
+    specifiedFinancialAdjustment.forEach(a => convertFinancialAdjustment(a, parent.addElement('ram:SpecifiedFinancialAdjustment')))
   }
 
   if (invoiceReferencedDocument && invoiceReferencedDocument.length > 0) {
-    invoiceReferencedDocument.forEach(d => convertReferencedDocument(d, parent.node('ram:InvoiceReferencedDocument')))
+    invoiceReferencedDocument.forEach(d => convertReferencedDocument(d, parent.addElement('ram:InvoiceReferencedDocument')))
   }
 
   if (receivableSpecifiedTradeAccountingAccount && receivableSpecifiedTradeAccountingAccount.length > 0) {
-    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.node('ram:ReceivableSpecifiedTradeAccountingAccount')))
+    receivableSpecifiedTradeAccountingAccount.forEach(a => convertTradeAccountingAccount(a, parent.addElement('ram:ReceivableSpecifiedTradeAccountingAccount')))
   }
 
   if (specifiedAdvancePayment && specifiedAdvancePayment.length > 0) {
-    specifiedAdvancePayment.forEach(p => convertAdvancePayment(p, parent.node('ram:SpecifiedAdvancePayment')))
+    specifiedAdvancePayment.forEach(p => convertAdvancePayment(p, parent.addElement('ram:SpecifiedAdvancePayment')))
   }
 }
 
 function convertTradeCurrencyExchange(
   { sourceCurrencyCode, targetCurrencyCode, conversionRate, conversionRateDateTime }: ram.TradeCurrencyExchangeType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  parent.node('ram:SourceCurrencyCode', sourceCurrencyCode.value)
-  parent.node('ram:TargetCurrencyCode', targetCurrencyCode.value)
-  parent.node('ram:ConversionRate', String(conversionRate.value))
+  parent.addElement('ram:SourceCurrencyCode').addText(sourceCurrencyCode.value)
+  parent.addElement('ram:TargetCurrencyCode').addText(targetCurrencyCode.value)
+  parent.addElement('ram:ConversionRate').addText(String(conversionRate.value))
   if (conversionRateDateTime) {
-    convertDateTime(conversionRateDateTime, parent.node('ram:ConversionRateDateTime'))
+    convertDateTime(conversionRateDateTime, parent.addElement('ram:ConversionRateDateTime'))
   }
 }
 
@@ -1017,43 +1021,43 @@ function convertPaymentMeans(
     payerSpecifiedDebtorFinancialInstitution,
     payeeSpecifiedCreditorFinancialInstitution,
   }: ram.TradeSettlementPaymentMeansType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  parent.node('ram:TypeCode', typeCode.value)
+  parent.addElement('ram:TypeCode').addText(typeCode.value)
   if (information) {
-    convertText(information, parent.node('ram:Information'))
+    convertText(information, parent.addElement('ram:Information'))
   }
   if (applicableTradeSettlementFinancialCard) {
-    const el = parent.node('ram:ApplicableTradeSettlementFinancialCard')
-    convertID(applicableTradeSettlementFinancialCard.id, el.node('ram:ID'))
+    const el = parent.addElement('ram:ApplicableTradeSettlementFinancialCard')
+    convertID(applicableTradeSettlementFinancialCard.id, el.addElement('ram:ID'))
     if (applicableTradeSettlementFinancialCard.cardholderName) {
-      convertText(applicableTradeSettlementFinancialCard.cardholderName, el.node('ram:CardholderName'))
+      convertText(applicableTradeSettlementFinancialCard.cardholderName, el.addElement('ram:CardholderName'))
     }
   }
   if (payerPartyDebtorFinancialAccount) {
-    const el = parent.node('ram:PayerPartyDebtorFinancialAccount')
-    convertID(payerPartyDebtorFinancialAccount.ibanID, el.node('ram:IBANID'))
+    const el = parent.addElement('ram:PayerPartyDebtorFinancialAccount')
+    convertID(payerPartyDebtorFinancialAccount.ibanID, el.addElement('ram:IBANID'))
     if (payerPartyDebtorFinancialAccount.accountName) {
-      convertText(payerPartyDebtorFinancialAccount.accountName, el.node('ram:AccountName'))
+      convertText(payerPartyDebtorFinancialAccount.accountName, el.addElement('ram:AccountName'))
     }
   }
   if (payeePartyCreditorFinancialAccount) {
-    const el = parent.node('ram:PayeePartyCreditorFinancialAccount')
+    const el = parent.addElement('ram:PayeePartyCreditorFinancialAccount')
     if (payeePartyCreditorFinancialAccount.ibanID) {
-      convertID(payeePartyCreditorFinancialAccount.ibanID, el.node('ram:IBANID'))
+      convertID(payeePartyCreditorFinancialAccount.ibanID, el.addElement('ram:IBANID'))
     }
     if (payeePartyCreditorFinancialAccount.accountName) {
-      convertText(payeePartyCreditorFinancialAccount.accountName, el.node('ram:AccountName'))
+      convertText(payeePartyCreditorFinancialAccount.accountName, el.addElement('ram:AccountName'))
     }
     if (payeePartyCreditorFinancialAccount.proprietaryID) {
-      convertID(payeePartyCreditorFinancialAccount.proprietaryID, el.node('ram:ProprietaryID'))
+      convertID(payeePartyCreditorFinancialAccount.proprietaryID, el.addElement('ram:ProprietaryID'))
     }
   }
   if (payerSpecifiedDebtorFinancialInstitution?.bicID) {
-    convertID(payerSpecifiedDebtorFinancialInstitution.bicID, parent.node('ram:PayerSpecifiedDebtorFinancialInstitution').node('ram:BICID'))
+    convertID(payerSpecifiedDebtorFinancialInstitution.bicID, parent.addElement('ram:PayerSpecifiedDebtorFinancialInstitution').addElement('ram:BICID'))
   }
   if (payeeSpecifiedCreditorFinancialInstitution?.bicID) {
-    convertID(payeeSpecifiedCreditorFinancialInstitution.bicID, parent.node('ram:PayeeSpecifiedCreditorFinancialInstitution').node('ram:BICID'))
+    convertID(payeeSpecifiedCreditorFinancialInstitution.bicID, parent.addElement('ram:PayeeSpecifiedCreditorFinancialInstitution').addElement('ram:BICID'))
   }
 }
 
@@ -1071,40 +1075,40 @@ function convertTradeTax(
     dueDateTypeCode,
     rateApplicablePercent,
   }: ram.TradeTaxType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (calculatedAmount) {
-    convertAmount(calculatedAmount, parent.node('ram:CalculatedAmount'))
+    convertAmount(calculatedAmount, parent.addElement('ram:CalculatedAmount'))
   }
   if (typeCode) {
-    parent.node('ram:TypeCode', typeCode.value)
+    parent.addElement('ram:TypeCode').addText(typeCode.value)
   }
   if (exemptionReason) {
-    convertText(exemptionReason, parent.node('ram:ExemptionReason'))
+    convertText(exemptionReason, parent.addElement('ram:ExemptionReason'))
   }
   if (basisAmount) {
-    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+    convertAmount(basisAmount, parent.addElement('ram:BasisAmount'))
   }
   if (lineTotalBasisAmount) {
-    convertAmount(lineTotalBasisAmount, parent.node('ram:LineTotalBasisAmount'))
+    convertAmount(lineTotalBasisAmount, parent.addElement('ram:LineTotalBasisAmount'))
   }
   if (allowanceChargeBasisAmount) {
-    convertAmount(allowanceChargeBasisAmount, parent.node('ram:AllowanceChargeBasisAmount'))
+    convertAmount(allowanceChargeBasisAmount, parent.addElement('ram:AllowanceChargeBasisAmount'))
   }
   if (categoryCode) {
-    parent.node('ram:CategoryCode', categoryCode.value)
+    parent.addElement('ram:CategoryCode').addText(categoryCode.value)
   }
   if (exemptionReasonCode) {
-    convertCode(exemptionReasonCode, parent.node('ram:ExemptionReasonCode'))
+    convertCode(exemptionReasonCode, parent.addElement('ram:ExemptionReasonCode'))
   }
   if (taxPointDate) {
-    convertDate(taxPointDate, parent.node('ram:TaxPointDate'))
+    convertDate(taxPointDate, parent.addElement('ram:TaxPointDate'))
   }
   if (dueDateTypeCode) {
-    parent.node('ram:DueDateTypeCode', dueDateTypeCode.value)
+    parent.addElement('ram:DueDateTypeCode').addText(dueDateTypeCode.value)
   }
   if (rateApplicablePercent) {
-    parent.node('ram:RateApplicablePercent', String(rateApplicablePercent.value))
+    parent.addElement('ram:RateApplicablePercent').addText(String(rateApplicablePercent.value))
   }
 }
 
@@ -1120,43 +1124,43 @@ function convertAllowanceCharge(
     reason,
     categoryTradeTax,
   }: ram.TradeAllowanceChargeType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  convertIndicator(chargeIndicator, parent.node('ram:ChargeIndicator'))
+  convertIndicator(chargeIndicator, parent.addElement('ram:ChargeIndicator'))
   if (sequenceNumeric) {
-    parent.node('ram:SequenceNumeric', String(sequenceNumeric.value))
+    parent.addElement('ram:SequenceNumeric').addText(String(sequenceNumeric.value))
   }
   if (calculationPercent) {
-    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+    parent.addElement('ram:CalculationPercent').addText(String(calculationPercent.value))
   }
   if (basisAmount) {
-    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+    convertAmount(basisAmount, parent.addElement('ram:BasisAmount'))
   }
   if (basisQuantity) {
-    convertQuantity(basisQuantity, parent.node('ram:BasisQuantity'))
+    convertQuantity(basisQuantity, parent.addElement('ram:BasisQuantity'))
   }
   if (actualAmount) {
-    convertAmount(actualAmount, parent.node('ram:ActualAmount'))
+    convertAmount(actualAmount, parent.addElement('ram:ActualAmount'))
   }
   if (reasonCode) {
-    parent.node('ram:ReasonCode', reasonCode.value)
+    parent.addElement('ram:ReasonCode').addText(reasonCode.value)
   }
   if (reason) {
-    convertText(reason, parent.node('ram:Reason'))
+    convertText(reason, parent.addElement('ram:Reason'))
   }
   if (categoryTradeTax) {
-    convertTradeTax(categoryTradeTax, parent.node('ram:CategoryTradeTax'))
+    convertTradeTax(categoryTradeTax, parent.addElement('ram:CategoryTradeTax'))
   }
 }
 
 function convertLogisticsServiceCharge(
   { description, appliedAmount, appliedTradeTax }: ram.LogisticsServiceChargeType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  convertText(description, parent.node('ram:Description'))
-  convertAmount(appliedAmount, parent.node('ram:AppliedAmount'))
+  convertText(description, parent.addElement('ram:Description'))
+  convertAmount(appliedAmount, parent.addElement('ram:AppliedAmount'))
   if (appliedTradeTax && appliedTradeTax.length > 0) {
-    appliedTradeTax.forEach(t => convertTradeTax(t, parent.node('ram:AppliedTradeTax')))
+    appliedTradeTax.forEach(t => convertTradeTax(t, parent.addElement('ram:AppliedTradeTax')))
   }
 }
 
@@ -1170,70 +1174,70 @@ function convertPaymentTerms(
     applicableTradePaymentDiscountTerms,
     payeeTradeParty,
   }: ram.TradePaymentTermsType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (description) {
-    convertText(description, parent.node('ram:Description'))
+    convertText(description, parent.addElement('ram:Description'))
   }
   if (dueDateDateTime) {
-    convertDateTime(dueDateDateTime, parent.node('ram:DueDateDateTime'))
+    convertDateTime(dueDateDateTime, parent.addElement('ram:DueDateDateTime'))
   }
   if (directDebitMandateID) {
-    convertID(directDebitMandateID, parent.node('ram:DirectDebitMandateID'))
+    convertID(directDebitMandateID, parent.addElement('ram:DirectDebitMandateID'))
   }
   if (partialPaymentAmount) {
-    convertAmount(partialPaymentAmount, parent.node('ram:PartialPaymentAmount'))
+    convertAmount(partialPaymentAmount, parent.addElement('ram:PartialPaymentAmount'))
   }
   if (applicableTradePaymentPenaltyTerms) {
-    convertPaymentPenaltyTerms(applicableTradePaymentPenaltyTerms, parent.node('ram:ApplicableTradePaymentPenaltyTerms'))
+    convertPaymentPenaltyTerms(applicableTradePaymentPenaltyTerms, parent.addElement('ram:ApplicableTradePaymentPenaltyTerms'))
   }
   if (applicableTradePaymentDiscountTerms) {
-    convertPaymentDiscountTerms(applicableTradePaymentDiscountTerms, parent.node('ram:ApplicableTradePaymentDiscountTerms'))
+    convertPaymentDiscountTerms(applicableTradePaymentDiscountTerms, parent.addElement('ram:ApplicableTradePaymentDiscountTerms'))
   }
   if (payeeTradeParty) {
-    convertTradeParty(payeeTradeParty, parent.node('ram:PayeeTradeParty'))
+    convertTradeParty(payeeTradeParty, parent.addElement('ram:PayeeTradeParty'))
   }
 }
 
 function convertPaymentPenaltyTerms(
   { basisDateTime, basisPeriodMeasure, basisAmount, calculationPercent, actualPenaltyAmount }: ram.TradePaymentPenaltyTermsType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (basisDateTime) {
-    convertDateTime(basisDateTime, parent.node('ram:BasisDateTime'))
+    convertDateTime(basisDateTime, parent.addElement('ram:BasisDateTime'))
   }
   if (basisPeriodMeasure) {
-    convertMeasure(basisPeriodMeasure, parent.node('ram:BasisPeriodMeasure'))
+    convertMeasure(basisPeriodMeasure, parent.addElement('ram:BasisPeriodMeasure'))
   }
   if (basisAmount) {
-    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+    convertAmount(basisAmount, parent.addElement('ram:BasisAmount'))
   }
   if (calculationPercent) {
-    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+    parent.addElement('ram:CalculationPercent').addText(String(calculationPercent.value))
   }
   if (actualPenaltyAmount) {
-    convertAmount(actualPenaltyAmount, parent.node('ram:ActualPenaltyAmount'))
+    convertAmount(actualPenaltyAmount, parent.addElement('ram:ActualPenaltyAmount'))
   }
 }
 
 function convertPaymentDiscountTerms(
   { basisDateTime, basisPeriodMeasure, basisAmount, calculationPercent, actualDiscountAmount }: ram.TradePaymentDiscountTermsType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (basisDateTime) {
-    convertDateTime(basisDateTime, parent.node('ram:BasisDateTime'))
+    convertDateTime(basisDateTime, parent.addElement('ram:BasisDateTime'))
   }
   if (basisPeriodMeasure) {
-    convertMeasure(basisPeriodMeasure, parent.node('ram:BasisPeriodMeasure'))
+    convertMeasure(basisPeriodMeasure, parent.addElement('ram:BasisPeriodMeasure'))
   }
   if (basisAmount) {
-    convertAmount(basisAmount, parent.node('ram:BasisAmount'))
+    convertAmount(basisAmount, parent.addElement('ram:BasisAmount'))
   }
   if (calculationPercent) {
-    parent.node('ram:CalculationPercent', String(calculationPercent.value))
+    parent.addElement('ram:CalculationPercent').addText(String(calculationPercent.value))
   }
   if (actualDiscountAmount) {
-    convertAmount(actualDiscountAmount, parent.node('ram:ActualDiscountAmount'))
+    convertAmount(actualDiscountAmount, parent.addElement('ram:ActualDiscountAmount'))
   }
 }
 
@@ -1249,56 +1253,56 @@ function convertTradeSettlementHeaderMonetarySummation(
     totalPrepaidAmount,
     duePayableAmount,
   }: ram.TradeSettlementHeaderMonetarySummationType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (lineTotalAmount) {
-    convertAmount(lineTotalAmount, parent.node('ram:LineTotalAmount'))
+    convertAmount(lineTotalAmount, parent.addElement('ram:LineTotalAmount'))
   }
   if (chargeTotalAmount) {
-    convertAmount(chargeTotalAmount, parent.node('ram:ChargeTotalAmount'))
+    convertAmount(chargeTotalAmount, parent.addElement('ram:ChargeTotalAmount'))
   }
   if (allowanceTotalAmount) {
-    convertAmount(allowanceTotalAmount, parent.node('ram:AllowanceTotalAmount'))
+    convertAmount(allowanceTotalAmount, parent.addElement('ram:AllowanceTotalAmount'))
   }
-  convertAmount(taxBasisTotalAmount, parent.node('ram:TaxBasisTotalAmount'))
+  convertAmount(taxBasisTotalAmount, parent.addElement('ram:TaxBasisTotalAmount'))
   if (taxTotalAmount && taxTotalAmount.length > 0) {
-    taxTotalAmount.forEach(a => convertAmount(a, parent.node('ram:TaxTotalAmount')))
+    taxTotalAmount.forEach(a => convertAmount(a, parent.addElement('ram:TaxTotalAmount')))
   }
   if (roundingAmount) {
-    convertAmount(roundingAmount, parent.node('ram:RoundingAmount'))
+    convertAmount(roundingAmount, parent.addElement('ram:RoundingAmount'))
   }
-  convertAmount(grandTotalAmount, parent.node('ram:GrandTotalAmount'))
+  convertAmount(grandTotalAmount, parent.addElement('ram:GrandTotalAmount'))
   if (totalPrepaidAmount) {
-    convertAmount(totalPrepaidAmount, parent.node('ram:TotalPrepaidAmount'))
+    convertAmount(totalPrepaidAmount, parent.addElement('ram:TotalPrepaidAmount'))
   }
-  convertAmount(duePayableAmount, parent.node('ram:DuePayableAmount'))
+  convertAmount(duePayableAmount, parent.addElement('ram:DuePayableAmount'))
 }
 
-function convertFinancialAdjustment({ reason, actualAmount }: ram.FinancialAdjustmentType, parent: XMLElement): void {
-  convertText(reason, parent.node('ram:Reason'))
-  convertAmount(actualAmount, parent.node('ram:ActualAmount'))
+function convertFinancialAdjustment({ reason, actualAmount }: ram.FinancialAdjustmentType, parent: XmlElement): void {
+  convertText(reason, parent.addElement('ram:Reason'))
+  convertAmount(actualAmount, parent.addElement('ram:ActualAmount'))
 }
 
-function convertTradeAccountingAccount({ id, typeCode }: ram.TradeAccountingAccountType, parent: XMLElement): void {
-  convertID(id, parent.node('ram:ID'))
+function convertTradeAccountingAccount({ id, typeCode }: ram.TradeAccountingAccountType, parent: XmlElement): void {
+  convertID(id, parent.addElement('ram:ID'))
   if (typeCode) {
-    parent.node('ram:TypeCode', typeCode.value)
+    parent.addElement('ram:TypeCode').addText(typeCode.value)
   }
 }
 
 function convertAdvancePayment(
   { paidAmount, formattedReceivedDateTime, includedTradeTax, invoiceSpecifiedReferencedDocument }: ram.AdvancePaymentType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
-  convertAmount(paidAmount, parent.node('ram:PaidAmount'))
+  convertAmount(paidAmount, parent.addElement('ram:PaidAmount'))
   if (formattedReceivedDateTime) {
-    convertFormattedDateTime(formattedReceivedDateTime, parent.node('ram:FormattedReceivedDateTime'))
+    convertFormattedDateTime(formattedReceivedDateTime, parent.addElement('ram:FormattedReceivedDateTime'))
   }
   if (includedTradeTax && includedTradeTax.length > 0) {
-    includedTradeTax.forEach(t => convertTradeTax(t, parent.node('ram:IncludedTradeTax')))
+    includedTradeTax.forEach(t => convertTradeTax(t, parent.addElement('ram:IncludedTradeTax')))
   }
   if (invoiceSpecifiedReferencedDocument) {
-    convertReferencedDocument(invoiceSpecifiedReferencedDocument, parent.node('ram:InvoiceSpecifiedReferencedDocument'))
+    convertReferencedDocument(invoiceSpecifiedReferencedDocument, parent.addElement('ram:InvoiceSpecifiedReferencedDocument'))
   }
 }
 
@@ -1308,30 +1312,30 @@ function convertAdvancePayment(
 
 function convertReferencedDocument(
   { issuerAssignedID, uriID, lineID, typeCode, name, attachmentBinaryObject, referenceTypeCode, formattedIssueDateTime }: ram.ReferencedDocumentType,
-  parent: XMLElement,
+  parent: XmlElement,
 ): void {
   if (issuerAssignedID) {
-    convertID(issuerAssignedID, parent.node('ram:IssuerAssignedID'))
+    convertID(issuerAssignedID, parent.addElement('ram:IssuerAssignedID'))
   }
   if (uriID) {
-    convertID(uriID, parent.node('ram:URIID'))
+    convertID(uriID, parent.addElement('ram:URIID'))
   }
   if (lineID) {
-    convertID(lineID, parent.node('ram:LineID'))
+    convertID(lineID, parent.addElement('ram:LineID'))
   }
   if (typeCode) {
-    parent.node('ram:TypeCode', typeCode.value)
+    parent.addElement('ram:TypeCode').addText(typeCode.value)
   }
   if (name && name.length > 0) {
-    name.forEach(n => convertText(n, parent.node('ram:Name')))
+    name.forEach(n => convertText(n, parent.addElement('ram:Name')))
   }
   if (attachmentBinaryObject) {
-    convertBinaryObject(attachmentBinaryObject, parent.node('ram:AttachmentBinaryObject'))
+    convertBinaryObject(attachmentBinaryObject, parent.addElement('ram:AttachmentBinaryObject'))
   }
   if (referenceTypeCode) {
-    parent.node('ram:ReferenceTypeCode', referenceTypeCode.value)
+    parent.addElement('ram:ReferenceTypeCode').addText(referenceTypeCode.value)
   }
   if (formattedIssueDateTime) {
-    convertFormattedDateTime(formattedIssueDateTime, parent.node('ram:FormattedIssueDateTime'))
+    convertFormattedDateTime(formattedIssueDateTime, parent.addElement('ram:FormattedIssueDateTime'))
   }
 }

--- a/src/lib/converters/facturx.ts
+++ b/src/lib/converters/facturx.ts
@@ -31,11 +31,19 @@ export async function invoiceToXml(invoice: CrossIndustryInvoiceType): Promise<X
 </rsm:CrossIndustryInvoice>`
 
   const doc = XmlDocument.fromString(xmlString)
-  const rootElement = doc.root
 
-  convertExchangedDocumentContext(invoice.exchangedDocumentContext, rootElement)
-  convertExchangedDocument(invoice.exchangedDocument, rootElement)
-  convertSupplyChainTradeTransaction(invoice.supplyChainTradeTransaction, rootElement)
+  try {
+    const rootElement = doc.root
+
+    convertExchangedDocumentContext(invoice.exchangedDocumentContext, rootElement)
+    convertExchangedDocument(invoice.exchangedDocument, rootElement)
+    convertSupplyChainTradeTransaction(invoice.supplyChainTradeTransaction, rootElement)
+  }
+  catch (error) {
+    // The caller owns the returned document, but only on success
+    doc.dispose()
+    throw error
+  }
 
   return doc
 }

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -68,7 +68,7 @@ export async function extract(options: {
     throw new Error('No attachment found')
   }
 
-  const xml = await resolveXml(Buffer.from(file.data))
+  using xml = await resolveXml(Buffer.from(file.data))
 
   if (options.check === true) {
     const result = await check({

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -11,7 +11,7 @@ import {
   AFRelationship,
   PDFHexString,
 } from 'pdf-lib'
-import pkg from '../../package.json' assert { type: 'json' }
+import pkg from '../../package.json' with { type: 'json' }
 
 import { check } from './check'
 import { FACTURX_CONFORMANCE_LEVEL, FACTURX_FILENAME, ORDERX_FILENAME, ZUGFERD_FILENAMES } from './constants'

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -32,101 +32,104 @@ export async function generate(options: {
 }): Promise<Uint8Array> {
   const xml = await resolveXml(options.xml)
 
-  const flavor = options.flavor || getFlavor(xml)
-  const level = options.level || getLevel(xml)
+  try {
+    const flavor = options.flavor || getFlavor(xml)
+    const level = options.level || getLevel(xml)
 
-  if (options.check === true) {
-    const result = await check({
-      xml,
-      flavor,
-      level,
+    if (options.check === true) {
+      const result = await check({
+        xml,
+        flavor,
+        level,
+      })
+      if (!result.valid) {
+        throw new Error(`Invalid XML format (${flavor} - ${level})`)
+      }
+    }
+
+    let meta = options.meta
+
+    if (!meta) {
+      const info = await extractBaseInfo(xml)
+      meta = baseInfo2PdfMetadata(info)
+    }
+    meta.date ||= new Date()
+
+    let description = ''
+    let filename = ''
+    let conformanceLevel = ''
+
+    switch (flavor) {
+      case 'facturx':
+        filename = FACTURX_FILENAME
+        description = 'Factur-X XML file'
+        conformanceLevel = FACTURX_CONFORMANCE_LEVEL[level as keyof typeof FACTURX_CONFORMANCE_LEVEL] || ''
+        break
+      case 'orderx':
+        filename = ORDERX_FILENAME
+        description = 'Order-X XML file'
+        break
+      case 'zugferd':
+        filename = ZUGFERD_FILENAMES[0]
+        description = 'ZUGFeRD XML file'
+        break
+      default:
+        throw new Error(`Unknown schema flavor: "${options.flavor}"`)
+    }
+
+    const pdf = await resolvePdf(options.pdf)
+
+    let documentId
+
+    if (pdf.context.trailerInfo.ID) {
+      throw new Error('Not implemented yet: Document ID already set')
+    }
+    else {
+      documentId = randomBytes(16).toString('hex')
+      const id = PDFHexString.of(documentId)
+      pdf.context.trailerInfo.ID = pdf.context.obj([id, id])
+    }
+
+    const encoder = new TextEncoder()
+    const uint8Array = encoder.encode(xml.toString())
+
+    await pdf.attach(uint8Array, filename, {
+      afRelationship: AFRelationship.Data,
+      mimeType: 'text/xml',
+      creationDate: meta.date,
+      modificationDate: meta.date,
+      description,
     })
-    if (!result.valid) {
-      throw new Error(`Invalid XML format (${flavor} - ${level})`)
+
+    const creator = `${pkg.name} npm lib v${pkg.version} (https://github.com/${pkg.repository})`
+
+    if (options.language) {
+      pdf.setLanguage(options.language)
+    }
+    pdf.setCreationDate(meta.date)
+    pdf.setModificationDate(meta.date)
+
+    pdf.setTitle(meta.title)
+    pdf.setSubject(meta.subject)
+    pdf.setAuthor(meta.author)
+    pdf.setKeywords(meta.keywords)
+    pdf.setCreator(creator)
+
+    setPDFA3BMetadata({
+      ...meta,
+      documentId,
+      filename,
+      conformanceLevel,
+      producer: creator,
+      creator,
+    }, pdf)
+
+    return await pdf.save()
+  }
+  finally {
+    if (!(options.xml instanceof XmlDocument)) {
+      // Dispose the XmlDocument instance if we created it within this function
+      xml.dispose()
     }
   }
-
-  let meta = options.meta
-
-  if (!meta) {
-    const info = await extractBaseInfo(xml)
-    meta = baseInfo2PdfMetadata(info)
-  }
-  meta.date ||= new Date()
-
-  let description = ''
-  let filename = ''
-  let conformanceLevel = ''
-
-  switch (flavor) {
-    case 'facturx':
-      filename = FACTURX_FILENAME
-      description = 'Factur-X XML file'
-      conformanceLevel = FACTURX_CONFORMANCE_LEVEL[level as keyof typeof FACTURX_CONFORMANCE_LEVEL] || ''
-      break
-    case 'orderx':
-      filename = ORDERX_FILENAME
-      description = 'Order-X XML file'
-      break
-    case 'zugferd':
-      filename = ZUGFERD_FILENAMES[0]
-      description = 'ZUGFeRD XML file'
-      break
-    default:
-      throw new Error(`Unknown schema flavor: "${options.flavor}"`)
-  }
-
-  const pdf = await resolvePdf(options.pdf)
-
-  let documentId
-
-  if (pdf.context.trailerInfo.ID) {
-    throw new Error('Not implemented yet: Document ID already set')
-  }
-  else {
-    documentId = randomBytes(16).toString('hex')
-    const id = PDFHexString.of(documentId)
-    pdf.context.trailerInfo.ID = pdf.context.obj([id, id])
-  }
-
-  const encoder = new TextEncoder()
-  const uint8Array = encoder.encode(xml.toString())
-
-  if (!(options.xml instanceof XmlDocument)) {
-    // Dispose the XmlDocument instance if we created it within this function
-    xml.dispose()
-  }
-
-  await pdf.attach(uint8Array, filename, {
-    afRelationship: AFRelationship.Data,
-    mimeType: 'text/xml',
-    creationDate: meta.date,
-    modificationDate: meta.date,
-    description,
-  })
-
-  const creator = `${pkg.name} npm lib v${pkg.version} (https://github.com/${pkg.repository})`
-
-  if (options.language) {
-    pdf.setLanguage(options.language)
-  }
-  pdf.setCreationDate(meta.date)
-  pdf.setModificationDate(meta.date)
-
-  pdf.setTitle(meta.title)
-  pdf.setSubject(meta.subject)
-  pdf.setAuthor(meta.author)
-  pdf.setKeywords(meta.keywords)
-  pdf.setCreator(creator)
-
-  setPDFA3BMetadata({
-    ...meta,
-    documentId,
-    filename,
-    conformanceLevel,
-    producer: creator,
-    creator,
-  }, pdf)
-
-  return await pdf.save()
 }

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,4 +1,4 @@
-import type { XMLDocument } from 'libxmljs'
+import type { XmlDocument } from 'libxml2-wasm'
 import type { Buffer } from 'node:buffer'
 import type {
   PDFDocument,
@@ -23,7 +23,7 @@ import { setPDFA3BMetadata } from './xmp'
 
 export async function generate(options: {
   pdf: string | Buffer | PDFDocument
-  xml: string | Buffer | XMLDocument
+  xml: string | Buffer | XmlDocument
   check?: boolean
   flavor?: string
   level?: string

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,12 +1,12 @@
-import type { XmlDocument } from 'libxml2-wasm'
 import type { Buffer } from 'node:buffer'
 import type {
   PDFDocument,
 } from 'pdf-lib'
-
 import type { PdfMetadata } from '../types'
 
 import { randomBytes } from 'node:crypto'
+
+import { XmlDocument } from 'libxml2-wasm'
 import {
   AFRelationship,
   PDFHexString,
@@ -91,6 +91,11 @@ export async function generate(options: {
 
   const encoder = new TextEncoder()
   const uint8Array = encoder.encode(xml.toString())
+
+  if (!(options.xml instanceof XmlDocument)) {
+    // Dispose the XmlDocument instance if we created it within this function
+    xml.dispose()
+  }
 
   await pdf.attach(uint8Array, filename, {
     afRelationship: AFRelationship.Data,

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -1,6 +1,6 @@
-import type { XMLElement } from 'libxmljs'
+import type { XmlElement } from 'libxml2-wasm'
 import type { Buffer } from 'node:buffer'
-import { parseXmlAsync } from 'libxmljs'
+import { XmlDocument } from 'libxml2-wasm'
 import {
   CrossIndustryInvoiceType,
   ExchangedDocumentContextType,
@@ -28,8 +28,8 @@ const NAMESPACES: NS = {
  * Mirrors the converter: every aggregate emitted by invoiceToXml is read back here.
  */
 export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryInvoiceType> {
-  const doc = await parseXmlAsync(xml)
-  const root = doc.root()
+  const doc = XmlDocument.fromString(xml.toString())
+  const root = doc.root
 
   if (!root) {
     throw new Error('Invalid XML: no root element')
@@ -46,79 +46,79 @@ export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryI
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function get(node: XMLElement | undefined, xpath: string): XMLElement | undefined {
+function get(node: XmlElement | undefined, xpath: string): XmlElement | undefined {
   if (!node) {
     return undefined
   }
-  return (node.get(xpath, NAMESPACES) as XMLElement) ?? undefined
+  return (node.get(xpath, NAMESPACES) as XmlElement) ?? undefined
 }
 
-function findAll(node: XMLElement | undefined, xpath: string): XMLElement[] {
+function findAll(node: XmlElement | undefined, xpath: string): XmlElement[] {
   if (!node) {
     return []
   }
-  return (node.find(xpath, NAMESPACES) as XMLElement[]) ?? []
+  return (node.find(xpath, NAMESPACES) as XmlElement[]) ?? []
 }
 
-function attr(node: XMLElement | undefined, name: string): string | undefined {
-  return node?.getAttribute(name)?.value() ?? undefined
+function attr(node: XmlElement | undefined, name: string): string | undefined {
+  return node?.attr(name)?.value ?? undefined
 }
 
-function textOf(node: XMLElement | undefined): string | undefined {
-  const t = node?.text()
+function textOf(node: XmlElement | undefined): string | undefined {
+  const t = node?.content
   return t === undefined || t === '' ? undefined : t
 }
 
-function parseID(node: XMLElement | undefined): udt.IDType | undefined {
+function parseID(node: XmlElement | undefined): udt.IDType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.IDType({ value: node.text() ?? '', schemeID: attr(node, 'schemeID') })
+  return new udt.IDType({ value: node.content ?? '', schemeID: attr(node, 'schemeID') })
 }
 
-function parseText(node: XMLElement | undefined): udt.TextType | undefined {
+function parseText(node: XmlElement | undefined): udt.TextType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.TextType({ value: node.text() ?? '' })
+  return new udt.TextType({ value: node.content ?? '' })
 }
 
-function parseCode(node: XMLElement | undefined): udt.CodeType | undefined {
+function parseCode(node: XmlElement | undefined): udt.CodeType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.CodeType({ value: node.text() ?? '', listID: attr(node, 'listID'), listVersionID: attr(node, 'listVersionID') })
+  return new udt.CodeType({ value: node.content ?? '', listID: attr(node, 'listID'), listVersionID: attr(node, 'listVersionID') })
 }
 
-function parseAmount(node: XMLElement | undefined): udt.AmountType | undefined {
+function parseAmount(node: XmlElement | undefined): udt.AmountType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.AmountType({ value: Number.parseFloat(node.text() || '0'), currencyID: attr(node, 'currencyID') })
+  return new udt.AmountType({ value: Number.parseFloat(node.content || '0'), currencyID: attr(node, 'currencyID') })
 }
 
-function parseQuantity(node: XMLElement | undefined): udt.QuantityType | undefined {
+function parseQuantity(node: XmlElement | undefined): udt.QuantityType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.QuantityType({ value: Number.parseFloat(node.text() || '0'), unitCode: attr(node, 'unitCode') })
+  return new udt.QuantityType({ value: Number.parseFloat(node.content || '0'), unitCode: attr(node, 'unitCode') })
 }
 
-function parseMeasure(node: XMLElement | undefined): udt.MeasureType | undefined {
+function parseMeasure(node: XmlElement | undefined): udt.MeasureType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.MeasureType({ value: Number.parseFloat(node.text() || '0'), unitCode: attr(node, 'unitCode') })
+  return new udt.MeasureType({ value: Number.parseFloat(node.content || '0'), unitCode: attr(node, 'unitCode') })
 }
 
-function parsePercent(node: XMLElement | undefined): udt.PercentType | undefined {
+function parsePercent(node: XmlElement | undefined): udt.PercentType | undefined {
   if (!node) {
     return undefined
   }
-  return new udt.PercentType({ value: Number.parseFloat(node.text() || '0') })
+  return new udt.PercentType({ value: Number.parseFloat(node.content || '0') })
 }
 
-function parseIndicator(node: XMLElement | undefined): udt.IndicatorType | undefined {
+function parseIndicator(node: XmlElement | undefined): udt.IndicatorType | undefined {
   if (!node) {
     return undefined
   }
@@ -126,38 +126,38 @@ function parseIndicator(node: XMLElement | undefined): udt.IndicatorType | undef
 }
 
 /** udt:DateTimeString child with a format attribute. */
-function parseDateTime(node: XMLElement | undefined): udt.DateTimeType | undefined {
+function parseDateTime(node: XmlElement | undefined): udt.DateTimeType | undefined {
   if (!node) {
     return undefined
   }
   const inner = get(node, './udt:DateTimeString')
-  return new udt.DateTimeType({ dateTimeString: inner?.text() ?? '', format: attr(inner, 'format') ?? '102' })
+  return new udt.DateTimeType({ dateTimeString: inner?.content ?? '', format: attr(inner, 'format') ?? '102' })
 }
 
 /** udt:DateString child with a format attribute. */
-function parseDate(node: XMLElement | undefined): udt.DateType | undefined {
+function parseDate(node: XmlElement | undefined): udt.DateType | undefined {
   if (!node) {
     return undefined
   }
   const inner = get(node, './udt:DateString')
-  return new udt.DateType({ dateString: inner?.text() ?? '', format: attr(inner, 'format') ?? '102' })
+  return new udt.DateType({ dateString: inner?.content ?? '', format: attr(inner, 'format') ?? '102' })
 }
 
 /** qdt:DateTimeString child (FormattedDateTimeType). */
-function parseFormattedDateTime(node: XMLElement | undefined): qdt.FormattedDateTimeType | undefined {
+function parseFormattedDateTime(node: XmlElement | undefined): qdt.FormattedDateTimeType | undefined {
   if (!node) {
     return undefined
   }
   const inner = get(node, './qdt:DateTimeString')
-  return new qdt.FormattedDateTimeType({ dateTimeString: inner?.text() ?? '', format: attr(inner, 'format') ?? '208' })
+  return new qdt.FormattedDateTimeType({ dateTimeString: inner?.content ?? '', format: attr(inner, 'format') ?? '208' })
 }
 
-function parseBinaryObject(node: XMLElement | undefined): udt.BinaryObjectType | undefined {
+function parseBinaryObject(node: XmlElement | undefined): udt.BinaryObjectType | undefined {
   if (!node) {
     return undefined
   }
   return new udt.BinaryObjectType({
-    value: node.text() ?? '',
+    value: node.content ?? '',
     mimeCode: attr(node, 'mimeCode') ?? '',
     filename: attr(node, 'filename') ?? '',
   })
@@ -167,7 +167,7 @@ function parseBinaryObject(node: XMLElement | undefined): udt.BinaryObjectType |
 // Document context / document
 // ---------------------------------------------------------------------------
 
-function parseExchangedDocumentContext(root: XMLElement): ExchangedDocumentContextType {
+function parseExchangedDocumentContext(root: XmlElement): ExchangedDocumentContextType {
   const contextNode = get(root, './rsm:ExchangedDocumentContext')
   if (!contextNode) {
     throw new Error('Invalid XML: no ExchangedDocumentContext element')
@@ -187,7 +187,7 @@ function parseExchangedDocumentContext(root: XMLElement): ExchangedDocumentConte
   })
 }
 
-function parseExchangedDocument(root: XMLElement): ExchangedDocumentType {
+function parseExchangedDocument(root: XmlElement): ExchangedDocumentType {
   const node = get(root, './rsm:ExchangedDocument')
   if (!node) {
     throw new Error('Invalid XML: no ExchangedDocument element')
@@ -205,7 +205,7 @@ function parseExchangedDocument(root: XMLElement): ExchangedDocumentType {
   })
 }
 
-function parseNote(node: XMLElement): ram.NoteType {
+function parseNote(node: XmlElement): ram.NoteType {
   return new ram.NoteType({
     contentCode: parseCode(get(node, './ram:ContentCode')),
     content: parseText(get(node, './ram:Content')) ?? new udt.TextType({ value: '' }),
@@ -213,7 +213,7 @@ function parseNote(node: XMLElement): ram.NoteType {
   })
 }
 
-function parseSpecifiedPeriod(node: XMLElement | undefined): ram.SpecifiedPeriodType | undefined {
+function parseSpecifiedPeriod(node: XmlElement | undefined): ram.SpecifiedPeriodType | undefined {
   if (!node) {
     return undefined
   }
@@ -229,7 +229,7 @@ function parseSpecifiedPeriod(node: XMLElement | undefined): ram.SpecifiedPeriod
 // Transaction
 // ---------------------------------------------------------------------------
 
-function parseSupplyChainTradeTransaction(root: XMLElement): SupplyChainTradeTransactionType {
+function parseSupplyChainTradeTransaction(root: XmlElement): SupplyChainTradeTransactionType {
   const node = get(root, './rsm:SupplyChainTradeTransaction')
   if (!node) {
     throw new Error('Invalid XML: no SupplyChainTradeTransaction element')
@@ -247,7 +247,7 @@ function parseSupplyChainTradeTransaction(root: XMLElement): SupplyChainTradeTra
 // Line items
 // ---------------------------------------------------------------------------
 
-function parseLineItem(node: XMLElement): ram.SupplyChainTradeLineItemType {
+function parseLineItem(node: XmlElement): ram.SupplyChainTradeLineItemType {
   const docLine = get(node, './ram:AssociatedDocumentLineDocument')
   const lineSettlement = get(node, './ram:SpecifiedLineTradeSettlement')
 
@@ -268,7 +268,7 @@ function parseLineItem(node: XMLElement): ram.SupplyChainTradeLineItemType {
   })
 }
 
-function parseTradeProduct(node: XMLElement | undefined): ram.TradeProductType {
+function parseTradeProduct(node: XmlElement | undefined): ram.TradeProductType {
   if (!node) {
     return new ram.TradeProductType({ name: new udt.TextType({ value: '' }) })
   }
@@ -301,7 +301,7 @@ function parseTradeProduct(node: XMLElement | undefined): ram.TradeProductType {
   })
 }
 
-function parseLineTradeAgreement(node: XMLElement | undefined): ram.LineTradeAgreementType | undefined {
+function parseLineTradeAgreement(node: XmlElement | undefined): ram.LineTradeAgreementType | undefined {
   if (!node) {
     return undefined
   }
@@ -319,7 +319,7 @@ function parseLineTradeAgreement(node: XMLElement | undefined): ram.LineTradeAgr
   })
 }
 
-function parseTradePrice(node: XMLElement | undefined): ram.TradePriceType | undefined {
+function parseTradePrice(node: XmlElement | undefined): ram.TradePriceType | undefined {
   if (!node) {
     return undefined
   }
@@ -331,7 +331,7 @@ function parseTradePrice(node: XMLElement | undefined): ram.TradePriceType | und
   })
 }
 
-function parseLineTradeDelivery(node: XMLElement | undefined): ram.LineTradeDeliveryType | undefined {
+function parseLineTradeDelivery(node: XmlElement | undefined): ram.LineTradeDeliveryType | undefined {
   if (!node) {
     return undefined
   }
@@ -349,7 +349,7 @@ function parseLineTradeDelivery(node: XMLElement | undefined): ram.LineTradeDeli
   })
 }
 
-function parseLineTradeSettlement(node: XMLElement | undefined): ram.LineTradeSettlementType {
+function parseLineTradeSettlement(node: XmlElement | undefined): ram.LineTradeSettlementType {
   if (!node) {
     return new ram.LineTradeSettlementType({ applicableTradeTax: [] })
   }
@@ -360,13 +360,13 @@ function parseLineTradeSettlement(node: XMLElement | undefined): ram.LineTradeSe
     specifiedTradeAllowanceCharge: findAll(node, './ram:SpecifiedTradeAllowanceCharge').map(parseAllowanceCharge),
     specifiedTradeSettlementLineMonetarySummation: sum
       ? new ram.TradeSettlementLineMonetarySummationType({
-        lineTotalAmount: parseAmount(get(sum, './ram:LineTotalAmount')) ?? new udt.AmountType({ value: 0 }),
-        chargeTotalAmount: parseAmount(get(sum, './ram:ChargeTotalAmount')),
-        allowanceTotalAmount: parseAmount(get(sum, './ram:AllowanceTotalAmount')),
-        taxTotalAmount: parseAmount(get(sum, './ram:TaxTotalAmount')),
-        grandTotalAmount: parseAmount(get(sum, './ram:GrandTotalAmount')),
-        totalAllowanceChargeAmount: parseAmount(get(sum, './ram:TotalAllowanceChargeAmount')),
-      })
+          lineTotalAmount: parseAmount(get(sum, './ram:LineTotalAmount')) ?? new udt.AmountType({ value: 0 }),
+          chargeTotalAmount: parseAmount(get(sum, './ram:ChargeTotalAmount')),
+          allowanceTotalAmount: parseAmount(get(sum, './ram:AllowanceTotalAmount')),
+          taxTotalAmount: parseAmount(get(sum, './ram:TaxTotalAmount')),
+          grandTotalAmount: parseAmount(get(sum, './ram:GrandTotalAmount')),
+          totalAllowanceChargeAmount: parseAmount(get(sum, './ram:TotalAllowanceChargeAmount')),
+        })
       : undefined,
     invoiceReferencedDocument: parseReferencedDocument(get(node, './ram:InvoiceReferencedDocument')),
     additionalReferencedDocument: findAll(node, './ram:AdditionalReferencedDocument').map(n => parseReferencedDocument(n)!),
@@ -378,7 +378,7 @@ function parseLineTradeSettlement(node: XMLElement | undefined): ram.LineTradeSe
 // Header agreement / delivery / settlement
 // ---------------------------------------------------------------------------
 
-function parseHeaderTradeAgreement(node: XMLElement): HeaderTradeAgreementType {
+function parseHeaderTradeAgreement(node: XmlElement): HeaderTradeAgreementType {
   const agreement = get(node, './ram:ApplicableHeaderTradeAgreement')
   if (!agreement) {
     throw new Error('Invalid XML: no ApplicableHeaderTradeAgreement element')
@@ -401,15 +401,15 @@ function parseHeaderTradeAgreement(node: XMLElement): HeaderTradeAgreementType {
     buyerAgentTradeParty: parseTradeParty(get(agreement, './ram:BuyerAgentTradeParty')),
     specifiedProcuringProject: get(agreement, './ram:SpecifiedProcuringProject')
       ? new ram.ProcuringProjectType({
-        id: new udt.IDType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:ID')) ?? '' }),
-        name: new udt.TextType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:Name')) ?? '' }),
-      })
+          id: new udt.IDType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:ID')) ?? '' }),
+          name: new udt.TextType({ value: textOf(get(agreement, './ram:SpecifiedProcuringProject/ram:Name')) ?? '' }),
+        })
       : undefined,
     ultimateCustomerOrderReferencedDocument: findAll(agreement, './ram:UltimateCustomerOrderReferencedDocument').map(n => parseReferencedDocument(n)!),
   })
 }
 
-function parseHeaderTradeDelivery(node: XMLElement): HeaderTradeDeliveryType {
+function parseHeaderTradeDelivery(node: XmlElement): HeaderTradeDeliveryType {
   const delivery = get(node, './ram:ApplicableHeaderTradeDelivery')
   if (!delivery) {
     return new HeaderTradeDeliveryType({})
@@ -425,7 +425,7 @@ function parseHeaderTradeDelivery(node: XMLElement): HeaderTradeDeliveryType {
   })
 }
 
-function parseSupplyChainEvent(node: XMLElement | undefined): ram.SupplyChainEventType | undefined {
+function parseSupplyChainEvent(node: XmlElement | undefined): ram.SupplyChainEventType | undefined {
   if (!node) {
     return undefined
   }
@@ -436,7 +436,7 @@ function parseSupplyChainEvent(node: XMLElement | undefined): ram.SupplyChainEve
   return new ram.SupplyChainEventType({ occurrenceDateTime: dt })
 }
 
-function parseHeaderTradeSettlement(node: XMLElement): HeaderTradeSettlementType {
+function parseHeaderTradeSettlement(node: XmlElement): HeaderTradeSettlementType {
   const settlement = get(node, './ram:ApplicableHeaderTradeSettlement')
   if (!settlement) {
     throw new Error('Invalid XML: no ApplicableHeaderTradeSettlement element')
@@ -472,7 +472,7 @@ function parseHeaderTradeSettlement(node: XMLElement): HeaderTradeSettlementType
   })
 }
 
-function parseHeaderMonetarySummation(node: XMLElement | undefined, currency: string): ram.TradeSettlementHeaderMonetarySummationType {
+function parseHeaderMonetarySummation(node: XmlElement | undefined, currency: string): ram.TradeSettlementHeaderMonetarySummationType {
   const zero = (): udt.AmountType => new udt.AmountType({ value: 0, currencyID: currency })
   if (!node) {
     return new ram.TradeSettlementHeaderMonetarySummationType({
@@ -498,7 +498,7 @@ function parseHeaderMonetarySummation(node: XMLElement | undefined, currency: st
 // Shared aggregates
 // ---------------------------------------------------------------------------
 
-function parseTradeParty(node: XMLElement | undefined): ram.TradePartyType | undefined {
+function parseTradeParty(node: XmlElement | undefined): ram.TradePartyType | undefined {
   if (!node) {
     return undefined
   }
@@ -511,10 +511,10 @@ function parseTradeParty(node: XMLElement | undefined): ram.TradePartyType | und
     description: parseText(get(node, './ram:Description')),
     specifiedLegalOrganization: legalOrg
       ? new ram.LegalOrganizationType({
-        id: parseID(get(legalOrg, './ram:ID')),
-        tradingBusinessName: parseText(get(legalOrg, './ram:TradingBusinessName')),
-        postalTradeAddress: parseTradeAddress(get(legalOrg, './ram:PostalTradeAddress')),
-      })
+          id: parseID(get(legalOrg, './ram:ID')),
+          tradingBusinessName: parseText(get(legalOrg, './ram:TradingBusinessName')),
+          postalTradeAddress: parseTradeAddress(get(legalOrg, './ram:PostalTradeAddress')),
+        })
       : undefined,
     definedTradeContact: findAll(node, './ram:DefinedTradeContact').map(parseTradeContact),
     postalTradeAddress: parseTradeAddress(get(node, './ram:PostalTradeAddress')),
@@ -528,7 +528,7 @@ function parseTradeParty(node: XMLElement | undefined): ram.TradePartyType | und
   })
 }
 
-function parseTradeContact(node: XMLElement): ram.TradeContactType {
+function parseTradeContact(node: XmlElement): ram.TradeContactType {
   return new ram.TradeContactType({
     personName: parseText(get(node, './ram:PersonName')),
     departmentName: parseText(get(node, './ram:DepartmentName')),
@@ -539,7 +539,7 @@ function parseTradeContact(node: XMLElement): ram.TradeContactType {
   })
 }
 
-function parseUniversalCommunication(node: XMLElement | undefined): ram.UniversalCommunicationType | undefined {
+function parseUniversalCommunication(node: XmlElement | undefined): ram.UniversalCommunicationType | undefined {
   if (!node) {
     return undefined
   }
@@ -549,7 +549,7 @@ function parseUniversalCommunication(node: XMLElement | undefined): ram.Universa
   })
 }
 
-function parseTradeAddress(node: XMLElement | undefined): ram.TradeAddressType | undefined {
+function parseTradeAddress(node: XmlElement | undefined): ram.TradeAddressType | undefined {
   if (!node) {
     return undefined
   }
@@ -564,7 +564,7 @@ function parseTradeAddress(node: XMLElement | undefined): ram.TradeAddressType |
   })
 }
 
-function parseTradeDeliveryTerms(node: XMLElement | undefined): ram.TradeDeliveryTermsType | undefined {
+function parseTradeDeliveryTerms(node: XmlElement | undefined): ram.TradeDeliveryTermsType | undefined {
   if (!node) {
     return undefined
   }
@@ -573,14 +573,14 @@ function parseTradeDeliveryTerms(node: XMLElement | undefined): ram.TradeDeliver
     deliveryTypeCode: new qdt.DeliveryTermsCodeType({ value: textOf(get(node, './ram:DeliveryTypeCode')) ?? '' }),
     relevantTradeLocation: loc
       ? new ram.TradeLocationType({
-        countryID: textOf(get(loc, './ram:CountryID')) ? new qdt.CountryIDType({ value: textOf(get(loc, './ram:CountryID'))! }) : undefined,
-        name: parseText(get(loc, './ram:Name')),
-      })
+          countryID: textOf(get(loc, './ram:CountryID')) ? new qdt.CountryIDType({ value: textOf(get(loc, './ram:CountryID'))! }) : undefined,
+          name: parseText(get(loc, './ram:Name')),
+        })
       : undefined,
   })
 }
 
-function parseTradeTax(node: XMLElement): ram.TradeTaxType {
+function parseTradeTax(node: XmlElement): ram.TradeTaxType {
   return new ram.TradeTaxType({
     calculatedAmount: parseAmount(get(node, './ram:CalculatedAmount')),
     typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.TaxTypeCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
@@ -596,7 +596,7 @@ function parseTradeTax(node: XMLElement): ram.TradeTaxType {
   })
 }
 
-function parseAllowanceCharge(node: XMLElement): ram.TradeAllowanceChargeType {
+function parseAllowanceCharge(node: XmlElement): ram.TradeAllowanceChargeType {
   return new ram.TradeAllowanceChargeType({
     chargeIndicator: parseIndicator(get(node, './ram:ChargeIndicator')) ?? new udt.IndicatorType({ indicator: false }),
     sequenceNumeric: textOf(get(node, './ram:SequenceNumeric')) ? new udt.NumericType({ value: Number.parseFloat(textOf(get(node, './ram:SequenceNumeric'))!) }) : undefined,
@@ -610,7 +610,7 @@ function parseAllowanceCharge(node: XMLElement): ram.TradeAllowanceChargeType {
   })
 }
 
-function parsePaymentTerms(node: XMLElement): ram.TradePaymentTermsType {
+function parsePaymentTerms(node: XmlElement): ram.TradePaymentTermsType {
   const penalty = get(node, './ram:ApplicableTradePaymentPenaltyTerms')
   const discount = get(node, './ram:ApplicableTradePaymentDiscountTerms')
   return new ram.TradePaymentTermsType({
@@ -620,27 +620,27 @@ function parsePaymentTerms(node: XMLElement): ram.TradePaymentTermsType {
     partialPaymentAmount: parseAmount(get(node, './ram:PartialPaymentAmount')),
     applicableTradePaymentPenaltyTerms: penalty
       ? new ram.TradePaymentPenaltyTermsType({
-        basisDateTime: parseDateTime(get(penalty, './ram:BasisDateTime')),
-        basisPeriodMeasure: parseMeasure(get(penalty, './ram:BasisPeriodMeasure')),
-        basisAmount: parseAmount(get(penalty, './ram:BasisAmount')),
-        calculationPercent: parsePercent(get(penalty, './ram:CalculationPercent')),
-        actualPenaltyAmount: parseAmount(get(penalty, './ram:ActualPenaltyAmount')),
-      })
+          basisDateTime: parseDateTime(get(penalty, './ram:BasisDateTime')),
+          basisPeriodMeasure: parseMeasure(get(penalty, './ram:BasisPeriodMeasure')),
+          basisAmount: parseAmount(get(penalty, './ram:BasisAmount')),
+          calculationPercent: parsePercent(get(penalty, './ram:CalculationPercent')),
+          actualPenaltyAmount: parseAmount(get(penalty, './ram:ActualPenaltyAmount')),
+        })
       : undefined,
     applicableTradePaymentDiscountTerms: discount
       ? new ram.TradePaymentDiscountTermsType({
-        basisDateTime: parseDateTime(get(discount, './ram:BasisDateTime')),
-        basisPeriodMeasure: parseMeasure(get(discount, './ram:BasisPeriodMeasure')),
-        basisAmount: parseAmount(get(discount, './ram:BasisAmount')),
-        calculationPercent: parsePercent(get(discount, './ram:CalculationPercent')),
-        actualDiscountAmount: parseAmount(get(discount, './ram:ActualDiscountAmount')),
-      })
+          basisDateTime: parseDateTime(get(discount, './ram:BasisDateTime')),
+          basisPeriodMeasure: parseMeasure(get(discount, './ram:BasisPeriodMeasure')),
+          basisAmount: parseAmount(get(discount, './ram:BasisAmount')),
+          calculationPercent: parsePercent(get(discount, './ram:CalculationPercent')),
+          actualDiscountAmount: parseAmount(get(discount, './ram:ActualDiscountAmount')),
+        })
       : undefined,
     payeeTradeParty: parseTradeParty(get(node, './ram:PayeeTradeParty')),
   })
 }
 
-function parsePaymentMeans(node: XMLElement): ram.TradeSettlementPaymentMeansType {
+function parsePaymentMeans(node: XmlElement): ram.TradeSettlementPaymentMeansType {
   const card = get(node, './ram:ApplicableTradeSettlementFinancialCard')
   const debtor = get(node, './ram:PayerPartyDebtorFinancialAccount')
   const creditor = get(node, './ram:PayeePartyCreditorFinancialAccount')
@@ -652,22 +652,22 @@ function parsePaymentMeans(node: XMLElement): ram.TradeSettlementPaymentMeansTyp
     information: parseText(get(node, './ram:Information')),
     applicableTradeSettlementFinancialCard: card
       ? new ram.TradeSettlementFinancialCardType({
-        id: new udt.IDType({ value: textOf(get(card, './ram:ID')) ?? '' }),
-        cardholderName: parseText(get(card, './ram:CardholderName')),
-      })
+          id: new udt.IDType({ value: textOf(get(card, './ram:ID')) ?? '' }),
+          cardholderName: parseText(get(card, './ram:CardholderName')),
+        })
       : undefined,
     payerPartyDebtorFinancialAccount: debtor
       ? new ram.DebtorFinancialAccountType({
-        ibanID: new udt.IDType({ value: textOf(get(debtor, './ram:IBANID')) ?? '' }),
-        accountName: parseText(get(debtor, './ram:AccountName')),
-      })
+          ibanID: new udt.IDType({ value: textOf(get(debtor, './ram:IBANID')) ?? '' }),
+          accountName: parseText(get(debtor, './ram:AccountName')),
+        })
       : undefined,
     payeePartyCreditorFinancialAccount: creditor
       ? new ram.CreditorFinancialAccountType({
-        ibanID: parseID(get(creditor, './ram:IBANID')),
-        accountName: parseText(get(creditor, './ram:AccountName')),
-        proprietaryID: parseID(get(creditor, './ram:ProprietaryID')),
-      })
+          ibanID: parseID(get(creditor, './ram:IBANID')),
+          accountName: parseText(get(creditor, './ram:AccountName')),
+          proprietaryID: parseID(get(creditor, './ram:ProprietaryID')),
+        })
       : undefined,
     payerSpecifiedDebtorFinancialInstitution: payerInst
       ? new ram.DebtorFinancialInstitutionType({ bicID: parseID(get(payerInst, './ram:BICID')) })
@@ -678,14 +678,14 @@ function parsePaymentMeans(node: XMLElement): ram.TradeSettlementPaymentMeansTyp
   })
 }
 
-function parseAccountingAccount(node: XMLElement): ram.TradeAccountingAccountType {
+function parseAccountingAccount(node: XmlElement): ram.TradeAccountingAccountType {
   return new ram.TradeAccountingAccountType({
     id: new udt.IDType({ value: textOf(get(node, './ram:ID')) ?? '' }),
     typeCode: textOf(get(node, './ram:TypeCode')) ? new qdt.AccountingAccountTypeCodeType({ value: textOf(get(node, './ram:TypeCode'))! }) : undefined,
   })
 }
 
-function parseReferencedDocument(node: XMLElement | undefined): ram.ReferencedDocumentType | undefined {
+function parseReferencedDocument(node: XmlElement | undefined): ram.ReferencedDocumentType | undefined {
   if (!node) {
     return undefined
   }

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -28,7 +28,9 @@ const NAMESPACES: NS = {
  * Mirrors the converter: every aggregate emitted by invoiceToXml is read back here.
  */
 export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryInvoiceType> {
-  using doc = XmlDocument.fromString(xml.toString())
+  using doc = typeof xml === 'string'
+    ? XmlDocument.fromString(xml)
+    : XmlDocument.fromBuffer(xml)
   const root = doc.root
 
   if (!root) {

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -28,7 +28,7 @@ const NAMESPACES: NS = {
  * Mirrors the converter: every aggregate emitted by invoiceToXml is read back here.
  */
 export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryInvoiceType> {
-  const doc = XmlDocument.fromString(xml.toString())
+  using doc = XmlDocument.fromString(xml.toString())
   const root = doc.root
 
   if (!root) {

--- a/src/lib/resolve.ts
+++ b/src/lib/resolve.ts
@@ -1,20 +1,24 @@
-import type { XMLParseOptions } from 'libxmljs'
-import type { Buffer } from 'node:buffer'
+import type { ParseOptions } from 'libxml2-wasm'
 import type { LoadOptions } from 'pdf-lib'
-import { parseXmlAsync, XMLDocument } from 'libxmljs'
+import { Buffer } from 'node:buffer'
+import { XmlDocument } from 'libxml2-wasm'
 import { PDFDocument } from 'pdf-lib'
 
 export async function resolveXml(
-  xml: string | Buffer | XMLDocument,
-  options: XMLParseOptions = {
-    encoding: 'utf8',
+  xml: string | Buffer | XmlDocument,
+  options: ParseOptions = {
+    encoding: 'utf-8',
   },
-): Promise<XMLDocument> {
-  if (xml instanceof XMLDocument) {
+): Promise<XmlDocument> {
+  if (xml instanceof XmlDocument) {
     return xml
   }
 
-  return await parseXmlAsync(xml, options)
+  if (Buffer.isBuffer(xml)) {
+    return XmlDocument.fromBuffer(xml, options)
+  }
+
+  return XmlDocument.fromString(xml, options)
 }
 
 export async function resolvePdf(

--- a/src/lib/xml.ts
+++ b/src/lib/xml.ts
@@ -1,4 +1,4 @@
-import type { XMLDocument, XMLElement } from 'libxmljs'
+import type { XmlDocument, XmlElement } from 'libxml2-wasm'
 import type { Buffer } from 'node:buffer'
 import type { BaseInfo } from '../types'
 import type {
@@ -11,25 +11,11 @@ import {
 } from './constants'
 import { resolveXml } from './resolve'
 
-export function extractNamespaces(fileDoc: XMLDocument): Record<string, string> {
-  // segfault - https://github.com/libxmljs/libxmljs/issues/649
-  // const namespaces = fileDoc.namespaces()
-  const str = fileDoc.toString()
-
-  const namespaces: Record<string, string> = {}
-
-  let match: RegExpExecArray | null
-
-  const xmlnsRe = /xmlns:([^=]+)="([^"]+)"/g
-  // eslint-disable-next-line no-cond-assign
-  while ((match = xmlnsRe.exec(str)) !== null) {
-    namespaces[match[1]] = match[2]
-  }
-
-  return namespaces
+export function extractNamespaces(fileDoc: XmlDocument): Record<string, string> {
+  return fileDoc.root.namespaces
 }
 
-export function getLevel(xmlDoc: XMLDocument): string {
+export function getLevel(xmlDoc: XmlDocument): string {
   const namespaces = extractNamespaces(xmlDoc)
 
   // Factur-X and Order-X
@@ -52,11 +38,11 @@ export function getLevel(xmlDoc: XMLDocument): string {
   }
   const xpathNode = doc_id_xpath[0]
 
-  if (!('text' in xpathNode)) {
+  if (!xpathNode.content) {
     throw new Error('No text found in the ID node')
   }
 
-  const doc_id = xpathNode?.text()?.split(':')
+  const doc_id = xpathNode?.content?.split(':')
   let level = doc_id[doc_id.length - 1]
 
   const possibleValues = new Set([...Object.keys(FACTURX_SCHEMA), ...Object.keys(ORDERX_SCHEMA)])
@@ -70,8 +56,8 @@ export function getLevel(xmlDoc: XMLDocument): string {
   return level
 }
 
-export function getFlavor(fileDoc: XMLDocument): string {
-  const tag = fileDoc.root()?.name()
+export function getFlavor(fileDoc: XmlDocument): string {
+  const tag = fileDoc.root?.name
   switch (tag) {
     case 'SCRDMCCBDACIOMessageStructure':
       return 'orderx'
@@ -83,14 +69,14 @@ export function getFlavor(fileDoc: XMLDocument): string {
   throw new Error(`XML not recognized as Factur-X, Order-X or ZUGFeRD`)
 }
 
-export async function extractBaseInfo(xml: string | Buffer | XMLDocument): Promise<BaseInfo> {
+export async function extractBaseInfo(xml: string | Buffer | XmlDocument): Promise<BaseInfo> {
   const xmlDoc = await resolveXml(xml)
 
   const namespaces = extractNamespaces(xmlDoc)
 
   const dateEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString', namespaces)
-  const dateStr = dateEl.text()
-  const dateFormat = dateEl.getAttribute('format')?.value() || '102'
+  const dateStr = dateEl.content
+  const dateFormat = dateEl.attr('format')?.value || '102'
   const formatMap = {
     // eslint-disable-next-line style/quote-props
     '102': 'yyyyMMdd',
@@ -100,16 +86,16 @@ export async function extractBaseInfo(xml: string | Buffer | XMLDocument): Promi
   const date = dateStr ? parse(dateStr, formatMap[dateFormat as keyof typeof formatMap], new Date()) : new Date()
 
   const numberEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:ID', namespaces)
-  const number = numberEl.text() || ''
+  const number = numberEl.content || ''
 
   const sellerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:Name', namespaces)
-  const seller = sellerEl.text() || ''
+  const seller = sellerEl.content || ''
 
   const buyerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:Name', namespaces)
-  const buyer = buyerEl.text() || ''
+  const buyer = buyerEl.content || ''
 
   const docTypeEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:TypeCode', namespaces)
-  const docType = docTypeEl.text() as DOC_TYPE_KEY || ''
+  const docType = docTypeEl.content as DOC_TYPE_KEY || ''
 
   return {
     seller,
@@ -160,10 +146,10 @@ export async function extractBaseInfo(xml: string | Buffer | XMLDocument): Promi
 //   return level
 // }
 
-function findXPath(fileDoc: XMLDocument, xpath: string, namespaces: Record<string, string>): XMLElement {
+function findXPath(fileDoc: XmlDocument, xpath: string, namespaces: Record<string, string>): XmlElement {
   const xpathNode = fileDoc.find(xpath, namespaces)
   if (!xpathNode.length) {
     throw new Error(`No ${xpath} found in the document`)
   }
-  return xpathNode[0] as XMLElement
+  return xpathNode[0] as XmlElement
 }

--- a/src/lib/xml.ts
+++ b/src/lib/xml.ts
@@ -73,42 +73,45 @@ export function getFlavor(fileDoc: XmlDocument): string {
 export async function extractBaseInfo(xml: string | Buffer | XmlDocument): Promise<BaseInfo> {
   const xmlDoc = await resolveXml(xml)
 
-  const namespaces = extractNamespaces(xmlDoc)
+  try {
+    const namespaces = extractNamespaces(xmlDoc)
 
-  const dateEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString', namespaces)
-  const dateStr = dateEl.content
-  const dateFormat = dateEl.attr('format')?.value || '102'
-  const formatMap = {
-    // eslint-disable-next-line style/quote-props
-    '102': 'yyyyMMdd',
-    // eslint-disable-next-line style/quote-props
-    '203': 'yyyyMMddHHmm',
-  } as const
-  const date = dateStr ? parse(dateStr, formatMap[dateFormat as keyof typeof formatMap], new Date()) : new Date()
+    const dateEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString', namespaces)
+    const dateStr = dateEl.content
+    const dateFormat = dateEl.attr('format')?.value || '102'
+    const formatMap = {
+      // eslint-disable-next-line style/quote-props
+      '102': 'yyyyMMdd',
+      // eslint-disable-next-line style/quote-props
+      '203': 'yyyyMMddHHmm',
+    } as const
+    const date = dateStr ? parse(dateStr, formatMap[dateFormat as keyof typeof formatMap], new Date()) : new Date()
 
-  const numberEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:ID', namespaces)
-  const number = numberEl.content || ''
+    const numberEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:ID', namespaces)
+    const number = numberEl.content || ''
 
-  const sellerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:Name', namespaces)
-  const seller = sellerEl.content || ''
+    const sellerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:Name', namespaces)
+    const seller = sellerEl.content || ''
 
-  const buyerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:Name', namespaces)
-  const buyer = buyerEl.content || ''
+    const buyerEl = findXPath(xmlDoc, '//ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:Name', namespaces)
+    const buyer = buyerEl.content || ''
 
-  const docTypeEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:TypeCode', namespaces)
-  const docType = docTypeEl.content as DOC_TYPE_KEY || ''
+    const docTypeEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:TypeCode', namespaces)
+    const docType = docTypeEl.content as DOC_TYPE_KEY || ''
 
-  if (!(xml instanceof XmlDocument)) {
-    // Dispose the XmlDocument instance if we created it within this function
-    xmlDoc.dispose()
+    return {
+      seller,
+      buyer,
+      number,
+      date,
+      docType,
+    }
   }
-
-  return {
-    seller,
-    buyer,
-    number,
-    date,
-    docType,
+  finally {
+    if (!(xml instanceof XmlDocument)) {
+      // Dispose the XmlDocument instance if we created it within this function
+      xmlDoc.dispose()
+    }
   }
 }
 // export function getOrderXLevel(fileDoc) {

--- a/src/lib/xml.ts
+++ b/src/lib/xml.ts
@@ -1,10 +1,11 @@
-import type { XmlDocument, XmlElement } from 'libxml2-wasm'
+import type { XmlElement } from 'libxml2-wasm'
 import type { Buffer } from 'node:buffer'
 import type { BaseInfo } from '../types'
 import type {
   DOC_TYPE_KEY,
 } from './constants'
 import { parse } from 'date-fns'
+import { XmlDocument } from 'libxml2-wasm'
 import {
   FACTURX_SCHEMA,
   ORDERX_SCHEMA,
@@ -96,6 +97,11 @@ export async function extractBaseInfo(xml: string | Buffer | XmlDocument): Promi
 
   const docTypeEl = findXPath(xmlDoc, '//rsm:ExchangedDocument/ram:TypeCode', namespaces)
   const docType = docTypeEl.content as DOC_TYPE_KEY || ''
+
+  if (!(xml instanceof XmlDocument)) {
+    // Dispose the XmlDocument instance if we created it within this function
+    xmlDoc.dispose()
+  }
 
   return {
     seller,

--- a/src/lib/xsd.ts
+++ b/src/lib/xsd.ts
@@ -1,4 +1,4 @@
-import type { XMLDocument } from 'libxmljs'
+import type { XmlDocument } from 'libxml2-wasm'
 import type {
   FACTURX_SCHEMA_TYPE,
   ORDERX_SCHEMA_TYPE,
@@ -6,15 +6,18 @@ import type {
 
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { xmlRegisterFsInputProviders } from 'libxml2-wasm/lib/nodejs.mjs'
 import {
   FACTURX_SCHEMA,
   ORDERX_SCHEMA,
 } from './constants'
 import { resolveXml } from './resolve'
 
-const _cache = {} as Record<string, Record<string, XMLDocument>>
+xmlRegisterFsInputProviders()
 
-export async function getXsd(flavor: string, level: string, cache = true): Promise<XMLDocument> {
+const _cache = {} as Record<string, Record<string, XmlDocument>>
+
+export async function getXsd(flavor: string, level: string, cache = true): Promise<XmlDocument> {
   if (cache && flavor in _cache && level in _cache[flavor]) {
     return _cache[flavor][level]
   }
@@ -40,7 +43,7 @@ export async function getXsd(flavor: string, level: string, cache = true): Promi
       throw new Error(`Unknown schema flavor: "${flavor}"`)
   }
 }
-export async function getFacturxXsd(level: FACTURX_SCHEMA_TYPE): Promise<XMLDocument> {
+export async function getFacturxXsd(level: FACTURX_SCHEMA_TYPE): Promise<XmlDocument> {
   if (!level || !(level in FACTURX_SCHEMA)) {
     throw new Error(`Unknown Factur-X level: "${level}", expected: "${Object.keys(FACTURX_SCHEMA).join('", "')}"`)
   }
@@ -52,7 +55,7 @@ export async function getFacturxXsd(level: FACTURX_SCHEMA_TYPE): Promise<XMLDocu
     url,
   })
 }
-export async function getOrderxXsd(level: ORDERX_SCHEMA_TYPE): Promise<XMLDocument> {
+export async function getOrderxXsd(level: ORDERX_SCHEMA_TYPE): Promise<XmlDocument> {
   if (!level || !(level in ORDERX_SCHEMA)) {
     throw new Error(`Unknown Order-X level: "${level}", expected: "${Object.keys(ORDERX_SCHEMA).join('", "')}"`)
   }

--- a/tests/generate/index.ts
+++ b/tests/generate/index.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
   const invoice = getMinimalFacturXModel()
   const xml = await invoiceToXml(invoice)
 
-  await writeFile(resolve(import.meta.dirname, './output.xml'), xml.toString({ format: false, whitespace: true }))
+  await writeFile(resolve(import.meta.dirname, './output.xml'), xml.toString({ format: false }))
 
   // const output = await pdf.save()
   const output = await generate({

--- a/tests/generate/index.ts
+++ b/tests/generate/index.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
   })
 
   const invoice = getMinimalFacturXModel()
-  const xml = await invoiceToXml(invoice)
+  using xml = await invoiceToXml(invoice)
 
   await writeFile(resolve(import.meta.dirname, './output.xml'), xml.toString({ format: false }))
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -8,7 +8,7 @@ import {
   HeaderTradeSettlementType,
   SupplyChainTradeTransactionType,
 } from '@stafyniaksacha/facturx/models'
-import { parseXmlAsync } from 'libxmljs'
+import { XmlDocument } from 'libxml2-wasm'
 import { describe, expect, it } from 'vitest'
 
 import { getExtendedFacturXModel } from './fixtures/model-extended'
@@ -29,11 +29,11 @@ describe('facturX XML Parser', () => {
   it.skip('should be similar to the minimum XML', async () => {
     const xml = getMinimumXML()
 
-    const parsed = await parseXmlAsync(xml)
-    const xmlString = parsed.toString({ format: true, whitespace: false })
+    const parsed = XmlDocument.fromString(xml)
+    const xmlString = parsed.toString({ format: true })
 
     const invoice = await xmlToInvoice(xml)
-    const invoiceString = (await invoiceToXml(invoice)).toString({ format: true, whitespace: false })
+    const invoiceString = (await invoiceToXml(invoice)).toString({ format: true })
 
     expect(invoiceString).toBeTypeOf('string')
     expect(xmlString).toBeTypeOf('string')


### PR DESCRIPTION
The dependency on `libxmljs` should be removed due to their unclear (likely abandoned) maintenance status, Node version requirements and potential bugs & CVEs. This PR replaces it with [libxml2-wasm](https://github.com/jameslan/libxml2-wasm) which is an actively maintained WebAssembly build of libxml2 with portable, system-independent binaries and browser support.

This introduces an implicit technical change: the memory allocated by the XmlDocument instances is not automatically subject to garbage disposal by the JavaScript engine (see https://jameslan.github.io/libxml2-wasm/v0.7/documents/Memory_Management.html). The user needs to take care of that (that is us, or the consumer of `invoiceToXml()`). 

I tried to dispose every instance that is created during runtime of this library in the happy-path, and added a note in the docs. I believe there are still leaks when an unexpected error occurs but is caught by the consumer of this library. Let me know if you think we should handle these cases as well.

I did not touch the commented-out `getOrderXLevel()` function, which still contains `libxmljs` references, and would leave that up to you :-)

Thank you for considering these changes!

Closes #7
Closes #13