### PR TITLE
fix(compatibility): replace using with const for IBM i compatibility

### DIFF
--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -29,7 +29,7 @@ export async function check(options: {
   const level = options.level || getLevel(xml)
 
   const xsd = await getXsd(flavor, level)
-  using validator = XsdValidator.fromDoc(xsd)
+  const validator = XsdValidator.fromDoc(xsd)
 
   let xsdValid = false
   let errors: any[] = []
@@ -42,8 +42,12 @@ export async function check(options: {
       errors = error.details
     }
     else {
+      validator.dispose()
       throw error
     }
+  }
+  finally {
+    validator.dispose()
   }
 
   const xmlString = xml.toString()

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -68,23 +68,28 @@ export async function extract(options: {
     throw new Error('No attachment found')
   }
 
-  using xml = await resolveXml(Buffer.from(file.data))
+  const xml = await resolveXml(Buffer.from(file.data))
 
-  if (options.check === true) {
-    const result = await check({
-      xml,
+  try {
+    if (options.check === true) {
+      const result = await check({
+        xml,
+        flavor,
+        level,
+      })
+      if (!result.valid) {
+        throw new Error('Invalid XML')
+      }
+    }
+
+    return {
+      filename: file.name,
+      xml: xml.toString(),
       flavor,
       level,
-    })
-    if (!result.valid) {
-      throw new Error('Invalid XML')
     }
   }
-
-  return {
-    filename: file.name,
-    xml: xml.toString(),
-    flavor,
-    level,
+  finally {
+    xml.dispose()
   }
 }

--- a/src/lib/parsers/facturx.ts
+++ b/src/lib/parsers/facturx.ts
@@ -28,20 +28,26 @@ const NAMESPACES: NS = {
  * Mirrors the converter: every aggregate emitted by invoiceToXml is read back here.
  */
 export async function xmlToInvoice(xml: string | Buffer): Promise<CrossIndustryInvoiceType> {
-  using doc = typeof xml === 'string'
+  const doc = typeof xml === 'string'
     ? XmlDocument.fromString(xml)
     : XmlDocument.fromBuffer(xml)
-  const root = doc.root
+  
+  try {
+    const root = doc.root
 
-  if (!root) {
-    throw new Error('Invalid XML: no root element')
+    if (!root) {
+      throw new Error('Invalid XML: no root element')
+    }
+
+    return new CrossIndustryInvoiceType({
+      exchangedDocumentContext: parseExchangedDocumentContext(root),
+      exchangedDocument: parseExchangedDocument(root),
+      supplyChainTradeTransaction: parseSupplyChainTradeTransaction(root),
+    })
   }
-
-  return new CrossIndustryInvoiceType({
-    exchangedDocumentContext: parseExchangedDocumentContext(root),
-    exchangedDocument: parseExchangedDocument(root),
-    supplyChainTradeTransaction: parseSupplyChainTradeTransaction(root),
-  })
+  finally {
+    doc.dispose()
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/generate/index.ts
+++ b/tests/generate/index.ts
@@ -48,19 +48,24 @@ async function main(): Promise<void> {
   })
 
   const invoice = getMinimalFacturXModel()
-  using xml = await invoiceToXml(invoice)
+  const xml = await invoiceToXml(invoice)
 
-  await writeFile(resolve(import.meta.dirname, './output.xml'), xml.toString({ format: false }))
+  try {
+    await writeFile(resolve(import.meta.dirname, './output.xml'), xml.toString({ format: false }))
 
-  // const output = await pdf.save()
-  const output = await generate({
-    pdf,
-    // @Todo: check why xpath is not working with direct xml object
-    // xml,
-    xml: xml.toString(),
-  })
+    // const output = await pdf.save()
+    const output = await generate({
+      pdf,
+      // @Todo: check why xpath is not working with direct xml object
+      // xml,
+      xml: xml.toString(),
+    })
 
-  await writeFile(resolve(import.meta.dirname, './output.pdf'), output)
+    await writeFile(resolve(import.meta.dirname, './output.pdf'), output)
+  }
+  finally {
+    xml.dispose()
+  }
 }
 
 main().catch(console.error)


### PR DESCRIPTION
Replaced `using` declarations with `const` to avoid compatibility issues on IBM i. The `using` syntax causes problems in the IBM i environment, so this change ensures the code can be processed correctly there.